### PR TITLE
refactor(be): 공통 `TagColor`이동 및 `ChatRoomEntity` color 컬럼 타입 수정

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/entity/ChatRoomEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/entity/ChatRoomEntity.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.chat.entity;
 
+import com.ourhour.global.common.enums.TagColor;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +19,9 @@ public class ChatRoomEntity {
     private Long roomId;
 
     private String name;
-    private String color;
+
+    @Enumerated(EnumType.STRING)
+    private TagColor color;
+
     private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/ourhour/domain/project/entity/IssueTagEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/project/entity/IssueTagEntity.java
@@ -1,6 +1,6 @@
 package com.ourhour.domain.project.entity;
 
-import com.ourhour.domain.project.enums.IssueTagColor;
+import com.ourhour.global.common.enums.TagColor;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,5 +17,5 @@ public class IssueTagEntity {
     private String name;
 
     @Enumerated(EnumType.STRING)
-    private IssueTagColor color;
+    private TagColor color;
 }

--- a/backend/src/main/java/com/ourhour/domain/project/enums/IssueTagColor.java
+++ b/backend/src/main/java/com/ourhour/domain/project/enums/IssueTagColor.java
@@ -1,9 +1,0 @@
-package com.ourhour.domain.project.enums;
-
-public enum IssueTagColor {
-    PINK,
-    YELLOW,
-    GREEN,
-    BLUE,
-    PURPLE;
-}

--- a/backend/src/main/java/com/ourhour/global/common/enums/TagColor.java
+++ b/backend/src/main/java/com/ourhour/global/common/enums/TagColor.java
@@ -1,0 +1,9 @@
+package com.ourhour.global.common.enums;
+
+public enum TagColor {
+    PINK,
+    YELLOW,
+    GREEN,
+    BLUE,
+    PURPLE;
+}

--- a/backend/src/test/java/com/ourhour/BackendApplicationTests.java
+++ b/backend/src/test/java/com/ourhour/BackendApplicationTests.java
@@ -1,4 +1,4 @@
-package com.backend;
+package com.ourhour;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 🔗 관련 이슈
x

## ✅ 작업 내용
- `IssueTagEntity`와 `ChatRoomEntity`에서 같은 `TagColor`가 사용되어 common.enums로 이동
- `color`컬럼의 타입을 String에서 TagColor(enum)로 변경

## 📝 기타 참고 사항
- 지원님이 작성하신 `IssueTagColor`를 `TagColor`로 수정 및 이동하였습니다.
