### PR TITLE
feat(be): Claim 생성 메소드 구현 및 로그인 API 구현, refreshToken Cookie 저장(OUR-USER-004)

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
@@ -1,10 +1,14 @@
 package com.ourhour.domain.auth.controller;
 
+import com.ourhour.domain.auth.dto.SigninResDTO;
 import com.ourhour.domain.auth.dto.SignupReqDTO;
 import com.ourhour.domain.auth.service.AuthService;
 import com.ourhour.global.common.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +22,9 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private long refreshTokenValidityInSeconds;
+
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<String>> signup(@Valid @RequestBody SignupReqDTO signupReqDTO) {
 
@@ -28,10 +35,28 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-//    @PostMapping("/signin")
-//    public ResponseEntity<ApiResponse<SigninResDTO>> signin(@Valid @RequestBody SignupReqDTO signupReqDTO) {
-//        return null;
-//    }
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResponse<SigninResDTO>> signin(@Valid @RequestBody SignupReqDTO signupReqDTO, HttpServletResponse response) {
+
+        SigninResDTO signinResDTO = authService.signin(signupReqDTO);
+
+        String refreshToken = signinResDTO.getRefreshToken();
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(false) // 개발 단계에서는 false, 배포 시에는 true
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(refreshTokenValidityInSeconds)
+                .build();
+
+        response.setHeader("Set-Cookie", cookie.toString());
+
+        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "로그인 완료");
+
+        return ResponseEntity.ok(signinResDTOApiResponse);
+    }
+
 //
 //    @PostMapping("/token")
 //

--- a/backend/src/main/java/com/ourhour/domain/auth/dto/SigninResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/dto/SigninResDTO.java
@@ -10,4 +10,6 @@ import lombok.NoArgsConstructor;
 public class SigninResDTO {
 
     private String accessToken;
+    private String refreshToken;
+
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/entity/RefreshTokenEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/entity/RefreshTokenEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,5 +33,13 @@ public class RefreshTokenEntity {
     private String token;
     private LocalDateTime createdAt;
     private LocalDateTime expiresAt;
+
+    @Builder
+    public RefreshTokenEntity(UserEntity userEntity, String token, LocalDateTime createdAt, LocalDateTime expiresAt) {
+        this.userEntity = userEntity;
+        this.token = token;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
@@ -24,6 +24,10 @@ public class AuthException extends BusinessException {
         return new AuthException(401, "비밀번호가 일치하지 않습니다.");
     }
 
+    public static AuthException invalidTokenException() {
+        return new AuthException(401, "토큰이 유효하지 않습니다.");
+    }
+
     public static AuthException emailVerificationException(String message) {
         return new AuthException(message);
     }

--- a/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,11 @@
 package com.ourhour.domain.auth.repository;
 
 import com.ourhour.domain.auth.entity.RefreshTokenEntity;
+import com.ourhour.domain.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
+    Optional<RefreshTokenEntity> findByUserEntity(UserEntity userEntity);
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
@@ -1,19 +1,29 @@
 package com.ourhour.domain.auth.service;
 
+import com.ourhour.domain.auth.dto.SigninResDTO;
 import com.ourhour.domain.auth.dto.SignupReqDTO;
+import com.ourhour.domain.auth.entity.RefreshTokenEntity;
 import com.ourhour.domain.auth.exception.AuthException;
 import com.ourhour.domain.auth.repository.EmailVerificationRepository;
 import com.ourhour.domain.auth.repository.RefreshTokenRepository;
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.repository.MemberRepository;
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.user.entity.UserEntity;
 import com.ourhour.domain.user.mapper.UserMapper;
 import com.ourhour.domain.user.repository.UserRepository;
 import com.ourhour.global.jwt.JwtTokenProvider;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.mapper.JwtClaimMapper;
+import com.ourhour.global.jwt.mapper.OrgAuthorityMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.ourhour.domain.auth.exception.AuthException.*;
 
@@ -24,10 +34,12 @@ public class AuthService {
     private final UserRepository userRepository;
     private final EmailVerificationRepository emailVerificationRepository;
     private final UserMapper userMapper;
-    private final PasswordEncoder passwordEncode;
-    private RefreshTokenRepository refreshTokenRepository;
-    private JwtTokenProvider jwtTokenProvider;
-    private PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtClaimMapper jwtClaimMapper;
+    private final OrgAuthorityMapper orgAuthorityMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void signup(SignupReqDTO signupReqDTO) {
@@ -43,7 +55,7 @@ public class AuthService {
         }
 
         // UserEntity 저장
-        String hashedPassword = passwordEncode.encode(signupReqDTO.getPassword());
+        String hashedPassword = passwordEncoder.encode(signupReqDTO.getPassword());
         UserEntity userEntity = userMapper.toUserEntity(signupReqDTO, hashedPassword , LocalDateTime.now());
 
         userRepository.save(userEntity);
@@ -51,7 +63,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void signin (SignupReqDTO signupReqDTO) {
+    public SigninResDTO signin (SignupReqDTO signupReqDTO) {
 
         // 이메일로 사용자 조회
         UserEntity userEntity = userRepository.findByEmail(signupReqDTO.getEmail())
@@ -62,11 +74,50 @@ public class AuthService {
             throw invalidPasswordException();
         }
 
-        // JWT 발급
+        // JWT token 발급
+        String accessToken = jwtTokenProvider.generateAccessToken(createClaims(userEntity));
+        String refreshToken = jwtTokenProvider.generateRefreshToken(createClaims(userEntity));
 
-        // refresh token 저장
+        // refresh token  DB 저장
+        saveRefreshToken(userEntity, refreshToken);
 
         // access token 반환
+        return new SigninResDTO(accessToken, refreshToken);
+
+    }
+
+    private Claims createClaims(UserEntity userEntity) {
+
+        // UserEntity와 연결된 모든 MemberEntity 조회
+        List<MemberEntity> memberEntityList = userEntity.getMemberEntityList();
+
+        // MemberEntity에 연결된 OrgParticipantMemberEntity 조회
+        List<OrgParticipantMemberEntity> orgParticipantMemberEntityList = new ArrayList<>();
+        for (MemberEntity memberEntity : memberEntityList) {
+            OrgParticipantMemberEntity orgParticipantMemberEntity = memberEntity.getOrgParticipantMemberEntity();
+            orgParticipantMemberEntityList.add(orgParticipantMemberEntity);
+        }
+
+        return jwtClaimMapper.createClaim(userEntity, orgParticipantMemberEntityList);
+
+    }
+
+    private void saveRefreshToken(UserEntity userEntity, String refreshToken) {
+
+        // 기존 refresh token 있다면 삭제
+        refreshTokenRepository.findByUserEntity(userEntity).ifPresent(refreshTokenRepository::delete);
+
+        // refresh token  DB 저장
+        LocalDateTime createdAt = jwtTokenProvider.getIatFromToken(refreshToken);
+        LocalDateTime expiredAt = jwtTokenProvider.getExpFromToken(refreshToken);
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity.builder()
+                .userEntity(userEntity)
+                .token(refreshToken)
+                .createdAt(createdAt)
+                .expiresAt(expiredAt)
+                .build();
+
+        refreshTokenRepository.save(refreshTokenEntity);
 
     }
 }

--- a/backend/src/main/java/com/ourhour/global/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/JwtTokenProvider.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -108,6 +110,24 @@ public class JwtTokenProvider {
         return Claims.builder()
                 .userId(Long.valueOf(jwtClaims.getSubject()))
                 .build();
+    }
+
+    // 토큰에서 생성 시간 추출
+    public LocalDateTime getIatFromToken(String token) {
+
+        io.jsonwebtoken.Claims jwtClaims = jwtClaimMapper.getJwtClaims(secretKey, token);
+        Date issuedAtDate = jwtClaims.getIssuedAt();
+
+        return issuedAtDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
+    // 토큰에서 만료 시간 추출
+    public LocalDateTime getExpFromToken(String token) {
+
+        io.jsonwebtoken.Claims jwtClaims = jwtClaimMapper.getJwtClaims(secretKey, token);
+        Date expiredAt = jwtClaims.getExpiration();
+
+        return expiredAt.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
     }
 
     // 토큰 유효성 검사

--- a/backend/src/main/java/com/ourhour/global/jwt/mapper/JwtClaimMapper.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/mapper/JwtClaimMapper.java
@@ -1,19 +1,39 @@
 package com.ourhour.global.jwt.mapper;
 
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import com.ourhour.domain.user.entity.UserEntity;
+import com.ourhour.global.jwt.dto.OrgAuthority;
 import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.util.List;
 
 @Component
 public class JwtClaimMapper {
 
-    // JWT Parsing (JWT token -> Claim(Payload) 매핑)
+    @Autowired
+    private OrgAuthorityMapper orgAuthorityMapper;
+
+    // Jwt 파싱 -> Claim 객체 추출
     public io.jsonwebtoken.Claims getJwtClaims(SecretKey secretKey, String token){
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    // Entity -> Custom Claims DTO 생성
+    public com.ourhour.global.jwt.dto.Claims createClaim(UserEntity userEntity, List<OrgParticipantMemberEntity> orgMembers) {
+
+        List<OrgAuthority> authorityList = orgAuthorityMapper.toOrgAuthority(orgMembers);
+
+        return com.ourhour.global.jwt.dto.Claims.builder()
+                .email(userEntity.getEmail())
+                .userId(userEntity.getUserId())
+                .orgAuthorityList(authorityList)
+                .build();
     }
 }

--- a/backend/src/main/java/com/ourhour/global/jwt/mapper/OrgAuthorityMapper.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/mapper/OrgAuthorityMapper.java
@@ -1,5 +1,6 @@
 package com.ourhour.global.jwt.mapper;
 
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.enums.Role;
 import com.ourhour.global.jwt.dto.OrgAuthority;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,7 @@ import java.util.stream.Collectors;
 @Component
 public class OrgAuthorityMapper {
 
-    // Map List -> List 변환 helper
+    // JWT 파싱 시 Map 리스트 → OrgAuthority 리스트로 변환
     public List<OrgAuthority> mapListToOrgAuthorityListHelper(List<Map<String, Object>> mapList) {
         if (mapList == null) return null;
 
@@ -25,4 +26,16 @@ public class OrgAuthorityMapper {
                 )
                 .collect(Collectors.toList());
     }
+
+    // JWT 발급 시 Entity → OrgAuthority 리스트로 변환
+    public List<OrgAuthority> toOrgAuthority (List<OrgParticipantMemberEntity> orgParticipantMemberEntityList) {
+        return orgParticipantMemberEntityList.stream()
+                .map(memberOrg -> OrgAuthority.builder()
+                        .orgId(memberOrg.getOrgEntity().getOrgId())
+                        .memberId(memberOrg.getMemberEntity().getMemberId())
+                        .role(memberOrg.getRole())
+                        .build()
+                ).collect(Collectors.toList());
+    }
+
 }

--- a/backend/src/test/java/com/ourhour/domain/auth/JwtTest.java
+++ b/backend/src/test/java/com/ourhour/domain/auth/JwtTest.java
@@ -4,6 +4,7 @@ import com.ourhour.domain.org.enums.Role;
 import com.ourhour.global.jwt.dto.Claims;
 import com.ourhour.global.jwt.JwtTokenProvider;
 import com.ourhour.global.jwt.dto.OrgAuthority;
+import com.ourhour.global.jwt.mapper.JwtClaimMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,9 @@ class JwtTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private JwtClaimMapper jwtClaimMapper;
 
     private Claims claims;
 


### PR DESCRIPTION
## 📌 제목
feat(be): Claim 생성 메소드 구현 및 로그인 API 구현, refreshToken Cookie 저장(OUR-USER-004)
----------------------------------------

## 🔗 관련 이슈
- Close #80 

## ✅ 작업 내용
- Claim 생성 메소드 구현
- 로그인 API 구현
- refreshToken Cookie 저장, DB 저장
- 로그인 시 응답 값으로 Access Token 응답 받음

## 📝 기타 참고 사항
- 응답 받은 Access Token은 프론트에서 사용자 메모리에 저장 예정
