### PR TITLE
feat(be): Claim activeOrgId 삭제, 로그아웃 API 구현(OUR-USER-006),  AccessToken 갱신 API 구현(OUR-USER-005)

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,9 +58,17 @@ public class AuthController {
         return ResponseEntity.ok(signinResDTOApiResponse);
     }
 
-//
-//    @PostMapping("/token")
-//
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<SigninResDTO>> reissueAccessToken (@CookieValue("refreshToken") String refreshToken) {
+
+        SigninResDTO signinResDTO = authService.reissueAccessToken(refreshToken);
+
+        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "토큰 재발급 완료");
+
+        return ResponseEntity.ok(signinResDTOApiResponse);
+    }
+
 //    @DeleteMapping("/token")
 
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
@@ -27,11 +27,11 @@ public class AuthController {
     private long refreshTokenValidityInSeconds;
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<String>> signup(@Valid @RequestBody SignupReqDTO signupReqDTO) {
+    public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupReqDTO signupReqDTO) {
 
         authService.signup(signupReqDTO);
 
-        ApiResponse response = ApiResponse.success("회원가입이 완료되었습니다.");
+        ApiResponse<Void> response = ApiResponse.success(null, "회원가입이 완료되었습니다.");
 
         return ResponseEntity.ok(response);
     }
@@ -53,7 +53,7 @@ public class AuthController {
 
         response.setHeader("Set-Cookie", cookie.toString());
 
-        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "로그인 완료");
+        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "로그인이 완료되었습니다.");
 
         return ResponseEntity.ok(signinResDTOApiResponse);
     }
@@ -64,11 +64,30 @@ public class AuthController {
 
         SigninResDTO signinResDTO = authService.reissueAccessToken(refreshToken);
 
-        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "토큰 재발급 완료");
+        ApiResponse<SigninResDTO> signinResDTOApiResponse = ApiResponse.success(new SigninResDTO(signinResDTO.getAccessToken(), null), "토큰 재발급이 완료되었습니다.");
 
         return ResponseEntity.ok(signinResDTOApiResponse);
     }
 
-//    @DeleteMapping("/token")
+    @PostMapping("/signout")
+    public ResponseEntity<ApiResponse<Void>> signout(HttpServletResponse response) {
+
+        System.out.println("잉??왜 안됨??");
+        authService.signout();
+
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(false) // 개발 단계에서는 false, 배포 시에는 true
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        response.setHeader("Set-Cookie", deleteCookie.toString());
+
+        ApiResponse<Void> apiResponse = ApiResponse.success(null,"로그아웃에 성공했습니다.");
+
+        return ResponseEntity.ok(apiResponse);
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
@@ -36,6 +36,10 @@ public class AuthException extends BusinessException {
         return new AuthException(404, "해당 유저가 존재하지 않습니다.");
     }
 
+    public static AuthException unauthorizedException() {
+        return new AuthException(401, "인증되지 않은 사용자입니다.");
+    }
+
     public static AuthException emailVerificationException(String message) {
         return new AuthException(message);
     }

--- a/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/exception/AuthException.java
@@ -28,6 +28,14 @@ public class AuthException extends BusinessException {
         return new AuthException(401, "토큰이 유효하지 않습니다.");
     }
 
+    public static AuthException tokenNotFoundException() {
+        return new AuthException(404, "토큰이 존재하지 않습니다.");
+    }
+
+    public static AuthException userNotFoundException() {
+        return new AuthException(404, "해당 유저가 존재하지 않습니다.");
+    }
+
     public static AuthException emailVerificationException(String message) {
         return new AuthException(message);
     }

--- a/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
     Optional<RefreshTokenEntity> findByUserEntity(UserEntity userEntity);
+
+    Optional<RefreshTokenEntity> findByToken(String refreshToken);
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/repository/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity
     Optional<RefreshTokenEntity> findByUserEntity(UserEntity userEntity);
 
     Optional<RefreshTokenEntity> findByToken(String refreshToken);
+
+    RefreshTokenEntity findByUserEntity_UserId(Long userId);
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
@@ -37,10 +37,9 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtClaimMapper jwtClaimMapper;
-    private final OrgAuthorityMapper orgAuthorityMapper;
     private final PasswordEncoder passwordEncoder;
-    private final MemberRepository memberRepository;
 
+    // 회원가입
     @Transactional
     public void signup(SignupReqDTO signupReqDTO) {
 
@@ -62,6 +61,7 @@ public class AuthService {
 
     }
 
+    // 로그인
     @Transactional
     public SigninResDTO signin (SignupReqDTO signupReqDTO) {
 
@@ -86,6 +86,7 @@ public class AuthService {
 
     }
 
+    // Claim 생성
     private Claims createClaims(UserEntity userEntity) {
 
         // UserEntity와 연결된 모든 MemberEntity 조회
@@ -102,6 +103,7 @@ public class AuthService {
 
     }
 
+    // refresh token 저장
     private void saveRefreshToken(UserEntity userEntity, String refreshToken) {
 
         // 기존 refresh token 있다면 삭제
@@ -120,4 +122,39 @@ public class AuthService {
         refreshTokenRepository.save(refreshTokenEntity);
 
     }
+
+    // access token 재발급
+    @Transactional
+    public SigninResDTO reissueAccessToken(String refreshToken) {
+
+        // 사용자로부터 받은 토큰 유효성 검사
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw tokenNotFoundException();
+        }
+
+        // DB 조회 및 유효성 검사
+        RefreshTokenEntity refreshTokenEntity = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(AuthException::tokenNotFoundException);
+
+        // refresh token 만료일 확인
+        if (refreshTokenEntity.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw invalidTokenException();
+        }
+
+        UserEntity userEntity = refreshTokenEntity.getUserEntity();
+        if (userEntity == null) {
+            throw userNotFoundException();
+        }
+
+        // access token 재발급
+        String accessToken = jwtTokenProvider.generateAccessToken(createClaims(userEntity));
+
+        // access token 반환
+        return new SigninResDTO(accessToken, null);
+
+    }
+
+
+
+
 }

--- a/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
@@ -7,7 +7,6 @@ import com.ourhour.domain.auth.exception.AuthException;
 import com.ourhour.domain.auth.repository.EmailVerificationRepository;
 import com.ourhour.domain.auth.repository.RefreshTokenRepository;
 import com.ourhour.domain.member.entity.MemberEntity;
-import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.user.entity.UserEntity;
 import com.ourhour.domain.user.mapper.UserMapper;
@@ -15,8 +14,9 @@ import com.ourhour.domain.user.repository.UserRepository;
 import com.ourhour.global.jwt.JwtTokenProvider;
 import com.ourhour.global.jwt.dto.Claims;
 import com.ourhour.global.jwt.mapper.JwtClaimMapper;
-import com.ourhour.global.jwt.mapper.OrgAuthorityMapper;
+import com.ourhour.global.jwt.util.UserContextHolder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -154,7 +154,22 @@ public class AuthService {
 
     }
 
+    @Transactional
+    public void signout() {
 
+        // 인증 정보 확인
+        Claims claims = UserContextHolder.get();
+        if (claims == null) {
+            throw unauthorizedException();
+        }
 
+        // db에서 refresh token 삭제
+        Long userId = claims.getUserId();
+        RefreshTokenEntity refreshTokenEntity = refreshTokenRepository.findByUserEntity_UserId(userId);
+        if (refreshTokenEntity != null) {
+            refreshTokenRepository.delete(refreshTokenEntity);
+        }
+
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(@NotBlank(message = "이메일은 필수입니다.") @Email String email);
 
     UserEntity findByPassword(String hashedPassword);
+
+    UserEntity findByUserId(Long userId);
 }

--- a/backend/src/main/java/com/ourhour/global/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/JwtTokenProvider.java
@@ -57,7 +57,6 @@ public class JwtTokenProvider {
                 .subject(String.valueOf(claims.getUserId()))
                 .claim("email", claims.getEmail())
                 .claim("userId", claims.getUserId())
-                .claim("activeOrgId", claims.getActiveOrgId())
                 .claim("orgAuthorityList",
                      claims.getOrgAuthorityList()
                           .stream().map(
@@ -97,7 +96,6 @@ public class JwtTokenProvider {
         return Claims.builder()
                 .email((String) jwtClaims.get("email"))
                 .userId(((Number) jwtClaims.get("userId")).longValue())
-                .activeOrgId(((Number)jwtClaims.get("activeOrgId")).longValue())
                 .orgAuthorityList(orgAuthorityMapper.mapListToOrgAuthorityListHelper(orgAuthoritiesRaw))
                 .build();
     }

--- a/backend/src/main/java/com/ourhour/global/jwt/dto/Claims.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/dto/Claims.java
@@ -15,7 +15,6 @@ public class Claims {
 
     private String email;
     private Long userId;
-    private Long activeOrgId;
     private List<OrgAuthority> orgAuthorityList;
 
 }

--- a/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
@@ -47,6 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
+
             String token = getToken(request);
 
             if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/backend/src/main/java/com/ourhour/global/jwt/mapper/JwtClaimMapper.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/mapper/JwtClaimMapper.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.util.ArrayList;
 import java.util.List;
 
 @Component
@@ -29,6 +30,10 @@ public class JwtClaimMapper {
     public com.ourhour.global.jwt.dto.Claims createClaim(UserEntity userEntity, List<OrgParticipantMemberEntity> orgMembers) {
 
         List<OrgAuthority> authorityList = orgAuthorityMapper.toOrgAuthority(orgMembers);
+
+        if(authorityList == null) {
+            authorityList = new ArrayList<>(); 
+        }
 
         return com.ourhour.global.jwt.dto.Claims.builder()
                 .email(userEntity.getEmail())

--- a/backend/src/test/java/com/ourhour/domain/auth/AuthTest.java
+++ b/backend/src/test/java/com/ourhour/domain/auth/AuthTest.java
@@ -36,7 +36,6 @@ public class AuthTest {
         claims = Claims.builder()
                 .email("test@example.com")
                 .userId(1L)
-                .activeOrgId(100L)
                 .orgAuthorityList(List.of(
                         new OrgAuthority(100L, 1L, Role.ADMIN),
                         new OrgAuthority(101L, 1L, Role.MEMBER)

--- a/backend/src/test/java/com/ourhour/domain/auth/JwtTest.java
+++ b/backend/src/test/java/com/ourhour/domain/auth/JwtTest.java
@@ -21,9 +21,6 @@ class JwtTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @Autowired
-    private JwtClaimMapper jwtClaimMapper;
-
     private Claims claims;
 
     @BeforeEach
@@ -31,10 +28,7 @@ class JwtTest {
         claims = Claims.builder()
                 .email("test@example.com")
                 .userId(1L)
-                .activeOrgId(100L)
                 .orgAuthorityList(List.of(
-                        new OrgAuthority(100L, 1L, Role.ADMIN),
-                        new OrgAuthority(101L, 1L, Role.MEMBER)
                 ))
                 .build();
     }
@@ -75,7 +69,6 @@ class JwtTest {
         assertThat(payloadFromAccessToken.getOrgAuthorityList()).isNotNull();
         assertThat(payloadFromAccessToken.getEmail()).isEqualTo(claims.getEmail());
         assertThat(payloadFromAccessToken.getUserId()).isEqualTo(claims.getUserId());
-        assertThat(payloadFromAccessToken.getActiveOrgId()).isEqualTo(claims.getActiveOrgId());
         assertThat(payloadFromAccessToken.getOrgAuthorityList().size()).isEqualTo(claims.getOrgAuthorityList().size());
 
         assertThat(payloadFromRefreshToken.getUserId()).isEqualTo(claims.getUserId());


### PR DESCRIPTION
## 📌 제목
feat(be): Claim activeOrgId 삭제, 로그아웃 API 구현(OUR-USER-006),  AccessToken 갱신 API 구현(OUR-USER-005)

## 🔗 관련 이슈
- Close #86 

## ✅ 작업 내용
- filter 제외 URI 추가 ("/api/auth/token")
- 민감 정보 응답에 대한 캐시 방지 헤더 추가
- Claim activeOrgId 삭제
- 로그아웃 API 구현(OUR-USER-006)
- AccessToken 갱신 API 구현(OUR-USER-005)

## 📝 기타 참고 사항
- POST api/auth/token : AccessToken 재발급
- POST api/auth/signout : 로그아웃
