### PR TITLE
feat(be): 채팅 기능 인증, 인가 기능 적용

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatController.java
@@ -3,11 +3,15 @@ package com.ourhour.domain.chat.controller;
 import com.ourhour.domain.chat.dto.ChatMessageReqDTO;
 import com.ourhour.domain.chat.dto.ChatMessageResDTO;
 import com.ourhour.domain.chat.service.ChatService;
+import com.ourhour.global.jwt.dto.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
 
 @Controller
 @RequiredArgsConstructor
@@ -17,11 +21,14 @@ public class ChatController {
     private final ChatService chatService;
 
     @MessageMapping("/chat/message")
-    public void message(@Payload ChatMessageReqDTO chatMessageReqDTO) {
+    public void message(@Payload ChatMessageReqDTO chatMessageReqDTO, Principal principal) {
 
-        ChatMessageResDTO chatMessageResDTO = chatService.saveAndConvertMessage(chatMessageReqDTO);
+        Claims claims = (Claims) ((UsernamePasswordAuthenticationToken) principal).getPrincipal();
+
+        ChatMessageResDTO chatMessageResDTO = chatService.saveAndConvertMessage(chatMessageReqDTO, claims);
 
         messagingTemplate.convertAndSend(
                 "/sub/chat/room/" + chatMessageResDTO.getChatRoomId(), chatMessageResDTO
-        );    }
+        );
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
@@ -2,6 +2,13 @@ package com.ourhour.domain.chat.controller;
 
 import com.ourhour.domain.chat.dto.*;
 import com.ourhour.domain.chat.service.ChatService;
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.global.exception.BusinessException;
+import com.ourhour.global.jwt.annotation.OrgAuth;
+import com.ourhour.global.jwt.annotation.OrgId;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.util.AuthorizationUtil;
+import com.ourhour.global.jwt.util.UserContextHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,70 +29,101 @@ public class ChatRestController {
 
     private final ChatService chatService;
 
+    private Long getMemberIdForOrg(Claims claims, Long orgId) {
+        return claims.getOrgAuthorityList().stream()
+                .filter(auth -> auth.getOrgId().equals(orgId))
+                .map(auth -> auth.getMemberId())
+                .findFirst()
+                .orElseThrow(() -> BusinessException.forbidden("해당 조직의 멤버가 아닙니다."));
+    }
+
+    @OrgAuth(accessLevel = Role.MEMBER)
     @GetMapping
     public List<ChatRoomListResDTO> getAllChatRooms(
-            @PathVariable Long orgId,
-            @RequestParam Long memberId) {
+            @OrgId @PathVariable Long orgId) {
+
+        Claims claims = UserContextHolder.get();
+        Long memberId = getMemberIdForOrg(claims, orgId);
 
         return chatService.findAllChatRooms(orgId, memberId);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @PostMapping
     public void registChatRoom(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @RequestBody ChatRoomCreateReqDTO request) {
 
         chatService.registerChatRoom(orgId, request);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @PutMapping("/{roomId}")
     public void modifyChatRoom(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId,
             @RequestBody ChatRoomUpdateReqDTO request) {
 
         chatService.modifyChatRoom(orgId, roomId, request);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @DeleteMapping("/{roomId}")
     public void deleteChatRoom(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId) {
 
         chatService.deleteChatRoom(orgId, roomId);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @GetMapping("/{roomId}/messages")
     public List<ChatMessageResDTO> getMessages(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId) {
 
         return chatService.findAllMessages(orgId, roomId);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @GetMapping("/{roomId}/participants")
     public List<ChatParticipantResDTO> getChatRoomParticipants(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId) {
 
         return chatService.findAllParticipants(orgId, roomId);
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @PostMapping("/{roomId}/participants")
     public void addChatRoomParticipant(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId,
             @RequestBody ParticipantAddReqDTO request) {
 
         chatService.addChatRoomParticipant(orgId, roomId, request.getMemberId());
     }
 
+    @OrgAuth(accessLevel = Role.MEMBER)
     @DeleteMapping("/{roomId}/participants/{memberId}")
     public void deleteChatRoomParticipant(
-            @PathVariable Long orgId,
+            @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId,
-            @PathVariable Long memberId) {
+            @PathVariable Long memberIdToDelete) {
 
-        chatService.deleteChatRoomParticipant(orgId, roomId, memberId);
+        Claims claims = UserContextHolder.get();
+        Long requestingMemberId = getMemberIdForOrg(claims, orgId);
+
+        // 자기 자신이 나가기
+        boolean isDeletingSelf = requestingMemberId.equals(memberIdToDelete);
+
+        // 관리자가 다른 멤버를 내보내기
+        boolean isAdminDeletingOther = AuthorizationUtil.isHigherThan(claims, orgId, Role.ADMIN);
+
+        if (isDeletingSelf || isAdminDeletingOther) {
+            chatService.deleteChatRoomParticipant(orgId, roomId, memberIdToDelete);
+        } else {
+            throw BusinessException.forbidden("채팅방에서 다른 멤버를 내보낼 권한이 없습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/ourhour/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/ourhour/global/config/WebSocketConfig.java
@@ -1,14 +1,28 @@
 package com.ourhour.global.config;
 
+import com.ourhour.global.jwt.JwtTokenProvider;
+import com.ourhour.global.jwt.dto.Claims;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -23,5 +37,42 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+    }
+
+    // WebSocket 인증을 위한 게이트웨이, 클라이언트 -> 서버로 들어오는 채널
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+
+        // 클라이언트가 WebSocket을 통해 보내는 모든 메시지가 인터셉터를 통과해야함
+        registration.interceptors(new ChannelInterceptor() {
+
+            // preSend: 보내기 직전 검사
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor =
+                        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                // 메시지가 전송될 때 마다 검증하지 않고 처음 연결을 시도할 경우에만 검증
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+
+                    // 헤더에서 JWT 추출
+                    String jwtToken = accessor.getFirstNativeHeader("Authorization");
+                    if (jwtToken != null && jwtToken.startsWith("Bearer ")) {
+                        jwtToken = jwtToken.substring(7);
+                    }
+
+                    // JWT validate 검사
+                    if (jwtTokenProvider.validateToken(jwtToken)) {
+                        // JWT에서 Claim 추출
+                        Claims claims = jwtTokenProvider.parseAccessToken(jwtToken);
+
+                        // 인증되면 Authentication 객체 붙여줌
+                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(claims, null, null);
+                        accessor.setUser(authentication);
+                    }
+                }
+                return message;
+            }
+        });
     }
 }


### PR DESCRIPTION

## 🔗 관련 이슈
- Close #90 

## ✅ 작업 내용
- `ChatRestController`에 `@OrgId`, `@OrgAuth`로 인가처리를 추가하였습니다.
- `ChatController`에 채팅 사용시의 인증 과정을 추가하였습니다.
- `WebSocketConfig`에 사용자가 연결될 때의 인증 과정을 추가하였습니다.

## 📝 기타 참고 사항
- 채팅방 나가기 로직을 작성한 부분에서 `ADMIN`이상의 권한을 가진 사용자는 다른 참가자를 추방할 수 있는 로직을 추가하였는데 사용할 지 여부는 논의해봐야 할 것 같습니다!