### PR TITLE
feat(fe): 채팅 컴포넌트 구조 리팩토링 및 api 호출부 수정

### DIFF
--- a/frontend/src/api/chat/chatApi.ts
+++ b/frontend/src/api/chat/chatApi.ts
@@ -1,17 +1,15 @@
-import axios from 'axios';
+import type { ChatRoom, ChatMessage } from '@/types/chatTypes';
 
-const API_BASE_URL = 'http://localhost:8080/api/chat-rooms';
+import axiosInstance from '@/api/axiosConfig.ts';
 
-export const getChatRoomList = async (memberId: number) => {
-  const response = await axios.get(`${API_BASE_URL}`, {
-    params: {
-      memberId: memberId.toString(),
-    },
-  });
+export const getChatRoomList = async (orgId: number) => {
+  const response = await axiosInstance.get<ChatRoom[]>(`/api/orgs/${orgId}/chat-rooms`);
   return response.data;
 };
 
-export const getChatMessages = async (roomId: number) => {
-  const response = await axios.get(`${API_BASE_URL}/${roomId}/messages`);
+export const getChatMessages = async (orgId: number, roomId: number) => {
+  const response = await axiosInstance.get<ChatMessage[]>(
+    `/api/orgs/${orgId}/chat-rooms/${roomId}/messages`,
+  );
   return response.data;
 };

--- a/frontend/src/components/chat/ChatMessageInput.tsx
+++ b/frontend/src/components/chat/ChatMessageInput.tsx
@@ -1,16 +1,15 @@
 import { useState } from 'react';
 
 interface ChatMessageInputProps {
-  onSendMessage: (message: string, senderId: number) => void;
+  onSendMessage: (message: string) => void;
 }
 
 export function ChatMessageInput({ onSendMessage }: ChatMessageInputProps) {
   const [message, setMessage] = useState('');
-  const senderId = 1;
 
   const handleSendMessage = () => {
     if (message.trim()) {
-      onSendMessage(message, senderId);
+      onSendMessage(message);
       setMessage('');
     }
   };

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'; // React.CSSProperties 타입을 위해 import
+import React from 'react';
 
 import type { ChatMessage } from '@/types/chatTypes';
 
@@ -47,7 +47,7 @@ export function ChatMessageList({ messages, currentMemberId }: ChatMessageListPr
             >
               {!isMyMessage && (
                 <span style={{ fontSize: '12px', color: '#666', marginBottom: '4px' }}>
-                  {msg.senderId}
+                  {msg.senderName}
                 </span>
               )}
 

--- a/frontend/src/components/chat/ChatRoomList.tsx
+++ b/frontend/src/components/chat/ChatRoomList.tsx
@@ -2,35 +2,25 @@ import { Link } from '@tanstack/react-router';
 
 import { ChatRoom } from '@/types/chatTypes.ts';
 
-import { useChatRoomListQuery } from '@/hooks/queries/chat/useChatRoomListQueries';
+interface ListProps {
+  chatRooms: ChatRoom[];
+}
 
-export const ChatRoomList = () => {
-  const { data: chatRooms, isLoading, isError, error } = useChatRoomListQuery(1);
-
-  if (isLoading) {
-    return <span>채팅방 목록을 불러오는 중...</span>;
-  }
-
-  if (isError) {
-    return <span>채팅방 목록을 불러오는데 실패하였습니다: {error.message}</span>;
-  }
-
-  return (
-    <div>
-      <h2>채팅방 목록</h2>
-      <ul>
-        {chatRooms?.map((chatRoom: ChatRoom) => (
-          <li key={chatRoom.roomId}>
-            <Link
-              to="/$orgId/chat/$roomId"
-              params={{ orgId: '1', roomId: String(chatRoom.roomId) }}
-            >
-              {chatRoom.name}
-            </Link>
-            <button>ℹ︎</button>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-};
+export const ChatRoomList = ({ chatRooms }: ListProps) => (
+  <ul>
+    {chatRooms?.map((chatRoom) => (
+      <li key={chatRoom.roomId}>
+        <Link to="/$orgId/chat/$roomId" params={{ orgId: '1', roomId: String(chatRoom.roomId) }}>
+          {chatRoom.name}
+        </Link>
+        <button>ℹ︎</button>
+      </li>
+    ))}
+    {!chatRooms ||
+      (chatRooms.length === 0 && (
+        <li>
+          <p>참여 중인 채팅방이 없습니다.</p>
+        </li>
+      ))}
+  </ul>
+);

--- a/frontend/src/hooks/queries/chat/useChatMessagesQueries.ts
+++ b/frontend/src/hooks/queries/chat/useChatMessagesQueries.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChatMessages } from '@/api/chat/chatApi.ts';
 
-export const useChatMessagesQuery = (roomId: number) =>
+export const useChatMessagesQuery = (orgId: number, roomId: number) =>
   useQuery({
-    queryKey: ['chatMessages', roomId],
-    queryFn: () => getChatMessages(roomId),
-    enabled: !!roomId,
+    queryKey: ['chatMessages', orgId, roomId],
+    queryFn: () => getChatMessages(orgId, roomId),
+    enabled: !!orgId && !!roomId,
   });

--- a/frontend/src/hooks/queries/chat/useChatRoomListQueries.ts
+++ b/frontend/src/hooks/queries/chat/useChatRoomListQueries.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChatRoomList } from '@/api/chat/chatApi.ts';
 
-export const useChatRoomListQuery = (memberId: number) =>
+export const useChatRoomListQuery = (orgId: number) =>
   useQuery({
-    queryKey: ['chatRooms', memberId],
-    queryFn: () => getChatRoomList(memberId),
-    enabled: !!memberId,
+    queryKey: ['chatRooms', orgId],
+    queryFn: () => getChatRoomList(orgId),
+    enabled: !!orgId,
   });

--- a/frontend/src/pages/chat/ChatRoomListPage.tsx
+++ b/frontend/src/pages/chat/ChatRoomListPage.tsx
@@ -1,0 +1,16 @@
+import { ChatRoom } from '@/types/chatTypes.ts';
+
+import { ChatRoomList } from '@/components/chat/ChatRoomList.tsx';
+import { ChatRoomListHeader } from '@/components/chat/ChatRoomListHeader.tsx';
+
+interface ChatRoomListPageProps {
+  chatRooms: ChatRoom[];
+}
+export function ChatRoomListPage({ chatRooms }: ChatRoomListPageProps) {
+  return (
+    <div>
+      <ChatRoomListHeader />
+      <ChatRoomList chatRooms={chatRooms} />
+    </div>
+  );
+}

--- a/frontend/src/pages/chat/ChatRoomPage.tsx
+++ b/frontend/src/pages/chat/ChatRoomPage.tsx
@@ -1,0 +1,34 @@
+import { ChatMessage } from '@/types/chatTypes.ts';
+
+import { ChatMessageInput } from '@/components/chat/ChatMessageInput.tsx';
+import { ChatMessageList } from '@/components/chat/ChatMessageList.tsx';
+
+interface ChatRoomPageProps {
+  messages: ChatMessage[];
+  sendMessage: (message: string) => void;
+  isConnected: boolean;
+  orgId: string;
+  roomId: string;
+}
+
+export function ChatRoomPage({
+  messages,
+  sendMessage,
+  isConnected,
+  orgId,
+  roomId,
+}: ChatRoomPageProps) {
+  const currentMemberId = 1;
+
+  return (
+    <div>
+      <h2>
+        {orgId}의 {roomId}번 채팅방
+      </h2>
+      <p>WebSocket 연결 상태 테스트: {isConnected ? '연결됨' : '연결안됨'}</p>
+      <hr />
+      <ChatMessageList messages={messages} currentMemberId={currentMemberId} />
+      <ChatMessageInput onSendMessage={sendMessage} />
+    </div>
+  );
+}

--- a/frontend/src/routes/$orgId/chat/$roomId/index.tsx
+++ b/frontend/src/routes/$orgId/chat/$roomId/index.tsx
@@ -4,29 +4,27 @@ import { createFileRoute, useParams } from '@tanstack/react-router';
 
 import { ChatMessage } from '@/types/chatTypes.ts';
 
-import { ChatMessageInput } from '@/components/chat/ChatMessageInput.tsx';
-import { ChatMessageList } from '@/components/chat/ChatMessageList.tsx';
 import { useChat } from '@/hooks/queries/chat/useChat.ts';
 import { useChatMessagesQuery } from '@/hooks/queries/chat/useChatMessagesQueries.ts';
+import { ChatRoomPage } from '@/pages/chat/ChatRoomPage.tsx';
 
-export const Route = createFileRoute('/$orgId/chat/$roomId')({
+export const Route = createFileRoute('/$orgId/chat/$roomId/')({
   component: ChatRoom,
 });
 
 function ChatRoom() {
-  const { orgId, roomId } = useParams({ from: '/$orgId/chat/$roomId' });
-  const { data: initialMessages, isLoading } = useChatMessagesQuery(Number(roomId));
+  const { orgId, roomId } = useParams({ from: '/$orgId/chat/$roomId/' });
+  const { data: initialMessages, isLoading } = useChatMessagesQuery(Number(orgId), Number(roomId));
   const { messages: newMessages, sendMessage, isConnected } = useChat(roomId);
 
   const [combinedMessages, setCombinedMessages] = useState<ChatMessage[]>([]);
-
-  const currentMemberId = 1;
 
   useEffect(() => {
     if (initialMessages) {
       setCombinedMessages(initialMessages);
     }
   }, [initialMessages]);
+
   useEffect(() => {
     if (newMessages.length > 0) {
       setCombinedMessages((prevMessages) => [...prevMessages, ...newMessages]);
@@ -38,14 +36,12 @@ function ChatRoom() {
   }
 
   return (
-    <div>
-      <h2>
-        {orgId}의 {roomId}번 채팅방
-      </h2>
-      <p>WebSocket 연결 상태 테스트: {isConnected ? '연결됨' : '연결안됨'}</p>
-      <hr />
-      <ChatMessageList messages={combinedMessages} currentMemberId={currentMemberId} />
-      <ChatMessageInput onSendMessage={sendMessage} />
-    </div>
+    <ChatRoomPage
+      messages={combinedMessages}
+      sendMessage={(message) => sendMessage(message, 1)}
+      isConnected={isConnected}
+      orgId={orgId}
+      roomId={roomId}
+    />
   );
 }

--- a/frontend/src/routes/$orgId/chat/index.tsx
+++ b/frontend/src/routes/$orgId/chat/index.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/$orgId/chat/')({
 
 function ChatListContainer() {
   const { orgId } = Route.useParams();
-  const { data: chatRooms=[], isLoading, isError, error } = useChatRoomListQuery(Number(orgId));
+  const { data: chatRooms = [], isLoading, isError, error } = useChatRoomListQuery(Number(orgId));
 
   if (isLoading) {
     return <span>채팅방 목록을 불러오는 중...</span>;

--- a/frontend/src/routes/$orgId/chat/index.tsx
+++ b/frontend/src/routes/$orgId/chat/index.tsx
@@ -1,17 +1,23 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import { ChatRoomList } from '@/components/chat/ChatRoomList.tsx';
-import { ChatRoomListHeader } from '@/components/chat/ChatRoomListHeader.tsx';
+import { useChatRoomListQuery } from '@/hooks/queries/chat/useChatRoomListQueries';
+import { ChatRoomListPage } from '@/pages/chat/ChatRoomListPage.tsx';
 
 export const Route = createFileRoute('/$orgId/chat/')({
-  component: RouteComponent,
+  component: ChatListContainer,
 });
 
-function RouteComponent() {
-  return (
-    <div>
-      <ChatRoomListHeader />
-      <ChatRoomList />
-    </div>
-  );
+function ChatListContainer() {
+  const { orgId } = Route.useParams();
+  const { data: chatRooms=[], isLoading, isError, error } = useChatRoomListQuery(Number(orgId));
+
+  if (isLoading) {
+    return <span>채팅방 목록을 불러오는 중...</span>;
+  }
+
+  if (isError) {
+    return <span>채팅방 목록을 불러오는데 실패하였습니다: {error.message}</span>;
+  }
+
+  return <ChatRoomListPage chatRooms={chatRooms} />;
 }

--- a/frontend/src/types/chatTypes.ts
+++ b/frontend/src/types/chatTypes.ts
@@ -2,6 +2,7 @@ export interface ChatMessage {
   chatRoomId: number;
   chatMessageId?: number | null;
   senderId: number;
+  senderName: string;
   message: string;
   timestamp?: string | null;
 }


### PR DESCRIPTION

## 🔗 관련 이슈
- Close #91 

## ✅ 작업 내용
- 기존의 하드코딩된 `Id`값을 제거하고 토큰을 사용하여 백엔드 엔드포인트를 호출하도록 수정하였습니다.
- 일관되지 않았던 컴포넌트 구조를 크게 `route`, `page`, `component`로 나누어 수정하였습니다. 

## 📝 기타 참고 사항
- x