### PR TITLE
fix: 채팅 메시지 전송 오류 관련 수정

### DIFF
--- a/frontend/src/components/chat/ChatMessageInput.tsx
+++ b/frontend/src/components/chat/ChatMessageInput.tsx
@@ -6,11 +6,19 @@ interface ChatMessageInputProps {
 
 export function ChatMessageInput({ onSendMessage }: ChatMessageInputProps) {
   const [message, setMessage] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
 
   const handleSendMessage = () => {
-    if (message.trim()) {
+    if (message.trim() && !isComposing) {
       onSendMessage(message);
       setMessage('');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !isComposing) {
+      e.preventDefault();
+      handleSendMessage();
     }
   };
 
@@ -20,7 +28,9 @@ export function ChatMessageInput({ onSendMessage }: ChatMessageInputProps) {
         type="text"
         value={message}
         onChange={(e) => setMessage(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
+        onKeyDown={handleKeyDown}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
       />
       <button onClick={handleSendMessage}>전송</button>
     </div>

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import type { ChatMessage } from '@/types/chatTypes';
 
@@ -21,6 +21,11 @@ interface ChatMessageListProps {
 }
 
 export function ChatMessageList({ messages, currentMemberId }: ChatMessageListProps) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
   return (
     <div style={{ border: '1px solid #ccc', height: '300px', overflowY: 'auto', padding: '10px' }}>
       {messages.map((msg) => {
@@ -50,8 +55,8 @@ export function ChatMessageList({ messages, currentMemberId }: ChatMessageListPr
                   {msg.senderName}
                 </span>
               )}
-
               <div style={bubbleStyle}>{msg.message}</div>
+              <div ref={endRef} />
             </div>
           </div>
         );

--- a/frontend/src/components/chat/ChatRoomList.tsx
+++ b/frontend/src/components/chat/ChatRoomList.tsx
@@ -3,24 +3,28 @@ import { Link } from '@tanstack/react-router';
 import { ChatRoom } from '@/types/chatTypes.ts';
 
 interface ListProps {
+  orgId: string;
   chatRooms: ChatRoom[];
 }
 
-export const ChatRoomList = ({ chatRooms }: ListProps) => (
+export const ChatRoomList = ({ chatRooms, orgId }: ListProps) => (
   <ul>
-    {chatRooms?.map((chatRoom) => (
-      <li key={chatRoom.roomId}>
-        <Link to="/$orgId/chat/$roomId" params={{ orgId: '1', roomId: String(chatRoom.roomId) }}>
-          {chatRoom.name}
-        </Link>
-        <button>ℹ︎</button>
-      </li>
-    ))}
-    {!chatRooms ||
-      (chatRooms.length === 0 && (
-        <li>
-          <p>참여 중인 채팅방이 없습니다.</p>
+    {chatRooms?.length > 0 ? (
+      chatRooms?.map((chatRoom) => (
+        <li key={chatRoom.roomId}>
+          <Link
+            to="/$orgId/chat/$roomId"
+            params={{ orgId: orgId, roomId: String(chatRoom.roomId) }}
+          >
+            {chatRoom.name}
+          </Link>
+          <button>ℹ︎</button>
         </li>
-      ))}
+      ))
+    ) : (
+      <li>
+        <p>참여 중인 채팅방이 없습니다.</p>
+      </li>
+    )}
   </ul>
 );

--- a/frontend/src/hooks/queries/chat/useChat.ts
+++ b/frontend/src/hooks/queries/chat/useChat.ts
@@ -5,6 +5,8 @@ import SockJS from 'sockjs-client';
 
 import type { ChatMessage, UseChatReturn } from '@/types/chatTypes.ts';
 
+import { getAccessTokenFromStore } from '@/utils/auth/tokenUtils';
+
 export function useChat(roomId: string | number): UseChatReturn {
   const clientRef = useRef<Client | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -29,8 +31,13 @@ export function useChat(roomId: string | number): UseChatReturn {
       return () => {};
     }
 
+    const accessToken = getAccessTokenFromStore();
+
     const client = new Client({
       webSocketFactory: () => new SockJS('http://localhost:8080/ws-stomp'),
+      connectHeaders: {
+        Authorization: `Bearer ${accessToken}`,
+      },
       onConnect: () => {
         client.subscribe(`/sub/chat/room/${roomId}`, (message: IMessage) => {
           const receivedMessage = JSON.parse(message.body);

--- a/frontend/src/hooks/queries/chat/useChat.ts
+++ b/frontend/src/hooks/queries/chat/useChat.ts
@@ -1,69 +1,71 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
-import { Client, type IMessage } from '@stomp/stompjs';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
-import type { ChatMessage, UseChatReturn } from '@/types/chatTypes.ts';
+import type { ChatMessage } from '@/types/chatTypes.ts';
 
 import { getAccessTokenFromStore } from '@/utils/auth/tokenUtils';
 
-export function useChat(roomId: string | number): UseChatReturn {
+export function useChat(orgId: number, roomId: number) {
+  const queryClient = useQueryClient();
   const clientRef = useRef<Client | null>(null);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [isConnected, setIsConnected] = useState<boolean>(false);
 
-  const sendMessage = (messageContent: string, senderId: number) => {
-    if (clientRef.current && clientRef.current.connected) {
-      const chatMessage = {
-        chatRoomId: roomId,
-        senderId: senderId,
-        message: messageContent,
-      };
+  useEffect(() => {
+    if (orgId && roomId && !clientRef.current) {
+      const accessToken = getAccessTokenFromStore();
+
+      const client = new Client({
+        webSocketFactory: () => new SockJS('http://localhost:8080/ws-stomp'),
+        connectHeaders: { Authorization: `Bearer ${accessToken}` },
+        onConnect: () => {
+          console.log('=== 웹소켓 연결 성공 ===');
+          client.subscribe(`/sub/chat/room/${roomId}`, (message) => {
+            const receivedMessage = JSON.parse(message.body) as ChatMessage;
+            queryClient.setQueryData<ChatMessage[]>(
+              ['chatMessages', orgId, roomId],
+              (oldData = []) => {
+                const exists = oldData.some(
+                  (m) => m.chatMessageId === receivedMessage.chatMessageId,
+                );
+                return exists ? oldData : [...oldData, receivedMessage];
+              },
+            );
+          });
+        },
+        onStompError: (frame) => {
+          console.error('STOMP Error:', frame.headers['message'], frame.body);
+        },
+      });
+
+      clientRef.current = client;
+      client.activate();
+    }
+
+    return () => {
+      if (clientRef.current?.connected) {
+        console.log('=== 웹소켓 연결을 해제합니다 ===');
+        clientRef.current.deactivate();
+        clientRef.current = null;
+      }
+    };
+  }, [orgId, roomId, queryClient]);
+
+  const sendMessage = (messageContent: string) => {
+    if (clientRef.current?.connected) {
       clientRef.current.publish({
         destination: '/pub/chat/message',
-        body: JSON.stringify(chatMessage),
+        body: JSON.stringify({
+          chatRoomId: roomId,
+          message: messageContent,
+        }),
       });
+    } else {
+      console.error('STOMP client is not connected.');
     }
   };
 
-  useEffect(() => {
-    if (!roomId) {
-      return () => {};
-    }
-
-    const accessToken = getAccessTokenFromStore();
-
-    const client = new Client({
-      webSocketFactory: () => new SockJS('http://localhost:8080/ws-stomp'),
-      connectHeaders: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-      onConnect: () => {
-        client.subscribe(`/sub/chat/room/${roomId}`, (message: IMessage) => {
-          const receivedMessage = JSON.parse(message.body);
-          setMessages((prevMessages) => [...prevMessages, receivedMessage]);
-        });
-        setIsConnected(true);
-        console.log('=== 웹소켓 연결 성공 ===');
-      },
-      onDisconnect: () => {
-        setIsConnected(false);
-        console.log('=== 웹소켓 연결 종료 ===');
-      },
-      onStompError: (frame) => {
-        console.error('=== STOMP 에러 ===', frame.headers.message, frame.body);
-      },
-    });
-
-    clientRef.current = client;
-    client.activate();
-
-    return () => {
-      if (clientRef.current) {
-        clientRef.current.deactivate();
-      }
-    };
-  }, [roomId]);
-
-  return { messages, sendMessage, isConnected };
+  return { sendMessage };
 }

--- a/frontend/src/pages/chat/ChatRoomListPage.tsx
+++ b/frontend/src/pages/chat/ChatRoomListPage.tsx
@@ -10,7 +10,7 @@ export function ChatRoomListPage({ chatRooms }: ChatRoomListPageProps) {
   return (
     <div>
       <ChatRoomListHeader />
-      <ChatRoomList chatRooms={chatRooms} />
+      <ChatRoomList chatRooms={chatRooms} orgId="1" />
     </div>
   );
 }

--- a/frontend/src/routes/$orgId/chat/$roomId/index.tsx
+++ b/frontend/src/routes/$orgId/chat/$roomId/index.tsx
@@ -1,8 +1,4 @@
-import { useEffect, useState } from 'react';
-
 import { createFileRoute, useParams } from '@tanstack/react-router';
-
-import { ChatMessage } from '@/types/chatTypes.ts';
 
 import { useChat } from '@/hooks/queries/chat/useChat.ts';
 import { useChatMessagesQuery } from '@/hooks/queries/chat/useChatMessagesQueries.ts';
@@ -14,31 +10,29 @@ export const Route = createFileRoute('/$orgId/chat/$roomId/')({
 
 function ChatRoom() {
   const { orgId, roomId } = useParams({ from: '/$orgId/chat/$roomId/' });
-  const { data: initialMessages, isLoading } = useChatMessagesQuery(Number(orgId), Number(roomId));
-  const { messages: newMessages, sendMessage, isConnected } = useChat(roomId);
+  const orgIdNum = Number(orgId);
+  const roomIdNum = Number(roomId);
+  const { isConnected, sendMessage } = useChat(orgIdNum, roomIdNum);
 
-  const [combinedMessages, setCombinedMessages] = useState<ChatMessage[]>([]);
-
-  useEffect(() => {
-    if (initialMessages) {
-      setCombinedMessages(initialMessages);
-    }
-  }, [initialMessages]);
-
-  useEffect(() => {
-    if (newMessages.length > 0) {
-      setCombinedMessages((prevMessages) => [...prevMessages, ...newMessages]);
-    }
-  }, [newMessages]);
+  const {
+    data: messages = [],
+    isLoading,
+    isError,
+    error,
+  } = useChatMessagesQuery(orgIdNum, roomIdNum);
 
   if (isLoading) {
     return <span>채팅 내역 불러오는 중...</span>;
   }
 
+  if (isError) {
+    return <span>채팅 내역을 불러오는데 실패하였습니다: {error.message}</span>;
+  }
+
   return (
     <ChatRoomPage
-      messages={combinedMessages}
-      sendMessage={(message) => sendMessage(message, 1)}
+      messages={messages}
+      sendMessage={(message) => sendMessage(message)}
       isConnected={isConnected}
       orgId={orgId}
       roomId={roomId}


### PR DESCRIPTION
## 🔗 관련 이슈
- x

## ✅ 작업 내용
- 메시지 전송 시 한글 입력으로 인해 발생하는 오류를 수정하였습니다.
- 새 메시지를 받으면 하단으로 자동 스크롤되는 로직을 추가하였습니다.
- 웹소켓 연결 시 관련 로직 수정 및 최적화 하였습니다.
  - 회사, 채팅방 id값이 유효할 경우에만 웹소켓 연결을 생성하고 활성화
  - 웹소켓이 두 번 호출되어 값 저장과 메시지 전송이 중복으로 되던 문제 해결
  - 웹소켓이 중복호출 되더라도 메시지가 중복되지 않도록 검증하는 로직 추가
## 📝 기타 참고 사항
- 테스트 방법, 추가로 공유할 내용

