### PR TITLE
feat(be): 회사 관련 및  구성원 관련 API 수정, 추가

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/member/entity/MemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/member/entity/MemberEntity.java
@@ -4,6 +4,7 @@ import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,6 +31,13 @@ public class MemberEntity {
 
     @OneToMany(mappedBy = "memberEntity", fetch = FetchType.LAZY)
     private List<OrgParticipantMemberEntity> orgParticipantMemberEntityList;
+
+    @Builder
+    public MemberEntity(UserEntity userEntity, String name, String email) {
+        this.userEntity = userEntity;
+        this.name = name;
+        this.email = email;
+    }
 
     public void anonymizeName(String suffix) {
         this.name = "Anonymous_" + suffix;

--- a/backend/src/main/java/com/ourhour/domain/member/exceptions/MemberException.java
+++ b/backend/src/main/java/com/ourhour/domain/member/exceptions/MemberException.java
@@ -1,0 +1,14 @@
+package com.ourhour.domain.member.exceptions;
+
+import com.ourhour.global.exception.BusinessException;
+
+public class MemberException extends BusinessException {
+
+    public MemberException(int status, String message) {
+        super(status, message);
+    }
+
+    public static MemberException memberNotFoundException() {
+        return new MemberException(404, "해당 멤버를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/member/repository/MemberRepository.java
@@ -32,4 +32,14 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
 
     List<MemberEntity> findByUserEntity_UserId(Long userId);
+
+    /* 본인이 속한 회사 내 자기 자신의 참여 정보 찾기 */
+    @Query("""
+        select opm.memberEntity
+        from OrgParticipantMemberEntity opm
+        where opm.orgEntity.orgId = :orgId
+          and opm.memberEntity.userEntity.userId = :userId
+          and opm.status = com.ourhour.domain.org.enums.Status.ACTIVE
+    """)
+    Optional<MemberEntity> findMemberInOrgByUserId(@Param("orgId")Long orgId, @Param("userId")Long actingUserId);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgController.java
@@ -5,6 +5,8 @@ import java.util.List;
 import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.org.dto.OrgDetailReqDTO;
 import com.ourhour.domain.org.dto.OrgDetailResDTO;
+import com.ourhour.domain.org.dto.OrgMemberRoleReqDTO;
+import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
 import com.ourhour.domain.org.dto.OrgReqDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
 import com.ourhour.domain.org.enums.Role;
@@ -24,15 +26,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/organizations")
@@ -50,6 +45,7 @@ public class OrgController {
     }
 
     // 회사 정보 조회
+    @OrgAuth
     @GetMapping("/{orgId}")
     public ResponseEntity<ApiResponse<OrgDetailResDTO>> getOrgInfo(@OrgId @PathVariable Long orgId) {
         OrgDetailResDTO orgDetailResDTO = orgService.getOrgInfo(orgId);
@@ -76,41 +72,14 @@ public class OrgController {
         return ResponseEntity.ok(ApiResponse.success(null, "팀 삭제에 성공하였습니다."));
     }
 
-    // 구성원 목록 조회
-    @GetMapping("/{orgId}/members")
-    public ResponseEntity<ApiResponse<PageResponse<MemberInfoResDTO>>> getOrgMembers(
-            @OrgId @PathVariable @Min(value = 1, message = "팀 ID는 1 이상이어야 합니다.") Long orgId,
-            @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.") int currentPage,
-            @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.") int size) {
-
-        Pageable pageable = PageRequest.of(currentPage, size);
-
-        PageResponse<MemberInfoResDTO> response = orgService.getOrgMembers(orgId, pageable);
-
-        return ResponseEntity.ok(ApiResponse.success(response, "팀 구성원 조회에 성공하였습니다."));
-    }
-
-    // 구성원 삭제
-    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
-    @DeleteMapping("/{orgId}/members/{memberId}")
-    public ResponseEntity<ApiResponse<Void>> deleteOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
-        orgService.deleteOrgMember(orgId, memberId);
-
-        return ResponseEntity.ok(ApiResponse.success(null, "팀 구성원 삭제에 성공하였습니다."));
-    }
-
 
 
     // 본인이 참여 중인 프로젝트 이름 목록 조회(좌측 사이드바)
+    @OrgAuth
     @GetMapping("/{orgId}/projects/my")
     public ResponseEntity<ApiResponse<List<ProjectNameResDTO>>> getMyProjects(@OrgId @PathVariable Long orgId) {
 
         Long memberId = 2L;
-
-        if (memberId == null || memberId <= 0) {
-            throw BusinessException.badRequest("유효하지 않은 멤버 ID입니다.");
-        }
-
         List<ProjectNameResDTO> response = orgService.getMyProjects(orgId, memberId);
         return ResponseEntity.ok(ApiResponse.success(response, "본인이 참여 중인 프로젝트 이름 목록 조회에 성공하였습니다."));
     }

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -1,0 +1,85 @@
+package com.ourhour.domain.org.controller;
+
+import com.ourhour.domain.member.dto.MemberInfoResDTO;
+import com.ourhour.domain.org.dto.OrgMemberRoleReqDTO;
+import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.service.OrgMemberService;
+import com.ourhour.global.common.dto.ApiResponse;
+import com.ourhour.global.common.dto.PageResponse;
+import com.ourhour.global.jwt.annotation.OrgAuth;
+import com.ourhour.global.jwt.annotation.OrgId;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/organizations")
+@RequiredArgsConstructor
+public class OrgMemberController {
+
+    private final OrgMemberService orgMemberService;
+
+    // 구성원 목록 조회
+    @OrgAuth
+    @GetMapping("/{orgId}/members")
+    public ResponseEntity<ApiResponse<PageResponse<MemberInfoResDTO>>> getOrgMembers(
+            @OrgId @PathVariable @Min(value = 1, message = "팀 ID는 1 이상이어야 합니다.") Long orgId,
+            @RequestParam(defaultValue = "1") @Min(value = 0, message = "페이지 번호는 1 이상이어야 합니다.") int currentPage,
+            @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.") int size) {
+
+        Pageable pageable = PageRequest.of(currentPage, size);
+
+        PageResponse<MemberInfoResDTO> response = orgMemberService.getOrgMembers(orgId, pageable);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "팀 구성원 조회에 성공하였습니다."));
+    }
+
+    // 구성원 상세 조회
+    @OrgAuth
+    @GetMapping("/{orgId}/members/{memberId}")
+    public ResponseEntity<ApiResponse<MemberInfoResDTO>> getOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
+
+        MemberInfoResDTO memberInfoResDTO = orgMemberService.getOrgMember(orgId, memberId);
+
+        ApiResponse<MemberInfoResDTO> apiResponse = ApiResponse.success(memberInfoResDTO, "구성원 상세 조회에 성공하셨습니다.");
+
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
+    // 구성원 권한 변경
+//    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
+    @PatchMapping("/{orgId}/members/{memberId}/role")
+    public ResponseEntity<ApiResponse<OrgMemberRoleResDTO>> getOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId, @RequestBody OrgMemberRoleReqDTO orgMemberRoleReqDTO) {
+
+        OrgMemberRoleResDTO orgMemberRoleResDTO = orgMemberService.changeRole(orgId, memberId, orgMemberRoleReqDTO);
+
+        ApiResponse<OrgMemberRoleResDTO> apiResponse = ApiResponse.success(orgMemberRoleResDTO, "구성원 변경 권한에 성공하셨습니다.");
+
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
+    // 구성원 삭제
+    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
+    @DeleteMapping("/{orgId}/members/{memberId}")
+    public ResponseEntity<ApiResponse<Void>> deleteOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
+        orgMemberService.deleteOrgMember(orgId, memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "팀 구성원 삭제에 성공하였습니다."));
+    }
+
+
+}

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -60,7 +60,7 @@ public class OrgMemberController {
     }
 
     // 구성원 권한 변경
-//    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
+    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
     @PatchMapping("/{orgId}/members/{memberId}/role")
     public ResponseEntity<ApiResponse<OrgMemberRoleResDTO>> getOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId, @RequestBody OrgMemberRoleReqDTO orgMemberRoleReqDTO) {
 
@@ -73,13 +73,16 @@ public class OrgMemberController {
     }
 
     // 구성원 삭제
-    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
+//    @OrgAuth(accessLevel = Role.ROOT_ADMIN)
     @DeleteMapping("/{orgId}/members/{memberId}")
     public ResponseEntity<ApiResponse<Void>> deleteOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
+
         orgMemberService.deleteOrgMember(orgId, memberId);
 
-        return ResponseEntity.ok(ApiResponse.success(null, "팀 구성원 삭제에 성공하였습니다."));
-    }
+        ApiResponse<Void> apiResponse = ApiResponse.success(null, "팀 구성원 삭제에 성공하였습니다.");
 
+        return ResponseEntity.ok(apiResponse);
+
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailReqDTO.java
@@ -14,10 +14,7 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrgReqDTO {
-
-    @NotBlank(message = "사용자 이름은 필수입니다.")
-    private String memberName;
+public class OrgDetailReqDTO {
 
     @NotBlank(message = "회사명은 필수입니다.")
     @Size(min = 2, max = 100, message = "이름은 2글자 이상입니다.")

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailResDTO.java
@@ -1,6 +1,5 @@
 package com.ourhour.domain.org.dto;
 
-import com.ourhour.domain.org.enums.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class OrgResDTO {
+public class OrgDetailResDTO {
 
     private Long orgId;
     private String name;
@@ -21,7 +20,5 @@ public class OrgResDTO {
     private String phone;
     private String businessNumber;
     private String logoImgUrl;
-    private String memberName;
-    private Role myRole;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleReqDTO.java
@@ -1,0 +1,16 @@
+package com.ourhour.domain.org.dto;
+
+import com.ourhour.domain.org.enums.Role;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OrgMemberRoleReqDTO {
+
+    private Role newRole;
+
+}

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleResDTO.java
@@ -1,0 +1,20 @@
+package com.ourhour.domain.org.dto;
+
+import com.ourhour.domain.org.enums.Role;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OrgMemberRoleResDTO {
+
+    private Long orgId;
+    private Long memberId;
+    private Role oldRole;
+    private Role newRole;
+    private int rootAdminCount;
+
+}

--- a/backend/src/main/java/com/ourhour/domain/org/entity/OrgEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/OrgEntity.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.org.entity;
 
+import com.ourhour.domain.org.dto.OrgDetailReqDTO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,7 +14,6 @@ import java.util.List;
 @Entity
 @Table(name = "tbl_org")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrgEntity {
 
@@ -24,21 +24,15 @@ public class OrgEntity {
     @OneToMany(mappedBy = "orgEntity")
     private List<OrgParticipantMemberEntity> orgParticipantMemberEntityList = new ArrayList<>();
 
-    @Setter
     private String name;
-    @Setter
     private String address;
-    @Setter
     private String email;
-    @Setter
     private String representativeName;
-    @Setter
     private String phone;
-    @Setter
     private String businessNumber;
-    @Setter
     private String logoImgUrl;
 
+    // 회사 등록
     @Builder
     public OrgEntity(String name, String address, String email, String representativeName, String phone,
             String businessNumber, String logoImgUrl) {
@@ -49,6 +43,17 @@ public class OrgEntity {
         this.phone = phone;
         this.businessNumber = businessNumber;
         this.logoImgUrl = logoImgUrl;
+    }
+
+    // 회사 정보 수정
+    public void updateInfo(OrgDetailReqDTO orgDetailReqDTO) {
+        if (orgDetailReqDTO.getName() != null) this.name = orgDetailReqDTO.getName();
+        if (orgDetailReqDTO.getAddress() != null) this.address = orgDetailReqDTO.getAddress();
+        if (orgDetailReqDTO.getEmail() != null) this.email = orgDetailReqDTO.getEmail();
+        if (orgDetailReqDTO.getRepresentativeName() != null) this.representativeName = orgDetailReqDTO.getRepresentativeName();
+        if (orgDetailReqDTO.getPhone() != null) this.phone = orgDetailReqDTO.getPhone();
+        if (orgDetailReqDTO.getBusinessNumber() != null) this.businessNumber = orgDetailReqDTO.getBusinessNumber();
+        if (orgDetailReqDTO.getLogoImgUrl() != null) this.logoImgUrl = orgDetailReqDTO.getLogoImgUrl();
     }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
@@ -5,6 +5,7 @@ import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.enums.Status;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Table(name = "tbl_org_participant_member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrgParticipantMemberEntity {
 
     @EmbeddedId
@@ -30,10 +32,6 @@ public class OrgParticipantMemberEntity {
     @MapsId("memberId")
     private MemberEntity memberEntity;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = true)
-    @JoinColumn(name="left_by_member_id")
-    private MemberEntity leftByMemberEntity;
-
     @ManyToOne
     @JoinColumn(name = "dept_id")
     private DepartmentEntity departmentEntity;
@@ -46,7 +44,8 @@ public class OrgParticipantMemberEntity {
     private Role role;
 
     @Enumerated(EnumType.STRING)
-    private Status status;
+    @Column(name = "status", nullable = false)
+    private Status status = Status.ACTIVE;
 
     private LocalDateTime joinedAt;
 

--- a/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
@@ -40,7 +40,7 @@ public class OrgParticipantMemberEntity {
 
     @Builder
     public OrgParticipantMemberEntity(OrgParticipantMemberId orgParticipantMemberId, OrgEntity orgEntity, MemberEntity memberEntity, DepartmentEntity departmentEntity, PositionEntity positionEntity, Role role) {
-        this.orgParticipantMemberId = orgParticipantMemberId;
+        this.orgParticipantMemberId = new OrgParticipantMemberId();
         this.orgEntity = orgEntity;
         this.memberEntity = memberEntity;
         this.departmentEntity = departmentEntity;

--- a/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -63,5 +64,13 @@ public class OrgParticipantMemberEntity {
 
     public void changeRole(Role newRole) {
         this.role = newRole;
+    }
+
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
+
+    public void markLeftNow() {
+        this.leftAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/OrgParticipantMemberEntity.java
@@ -2,11 +2,14 @@ package com.ourhour.domain.org.entity;
 
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.enums.Status;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "tbl_org_participant_member")
@@ -27,6 +30,10 @@ public class OrgParticipantMemberEntity {
     @MapsId("memberId")
     private MemberEntity memberEntity;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name="left_by_member_id")
+    private MemberEntity leftByMemberEntity;
+
     @ManyToOne
     @JoinColumn(name = "dept_id")
     private DepartmentEntity departmentEntity;
@@ -38,6 +45,13 @@ public class OrgParticipantMemberEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private LocalDateTime joinedAt;
+
+    private LocalDateTime leftAt;
+
     @Builder
     public OrgParticipantMemberEntity(OrgParticipantMemberId orgParticipantMemberId, OrgEntity orgEntity, MemberEntity memberEntity, DepartmentEntity departmentEntity, PositionEntity positionEntity, Role role) {
         this.orgParticipantMemberId = new OrgParticipantMemberId();
@@ -46,5 +60,9 @@ public class OrgParticipantMemberEntity {
         this.departmentEntity = departmentEntity;
         this.positionEntity = positionEntity;
         this.role = role;
+    }
+
+    public void changeRole(Role newRole) {
+        this.role = newRole;
     }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/enums/Status.java
+++ b/backend/src/main/java/com/ourhour/domain/org/enums/Status.java
@@ -1,0 +1,6 @@
+package com.ourhour.domain.org.enums;
+
+public enum Status {
+    ACTIVE,
+    INACTIVE;
+}

--- a/backend/src/main/java/com/ourhour/domain/org/enums/Status.java
+++ b/backend/src/main/java/com/ourhour/domain/org/enums/Status.java
@@ -3,4 +3,6 @@ package com.ourhour.domain.org.enums;
 public enum Status {
     ACTIVE,
     INACTIVE;
+
+    Status() {}
 }

--- a/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
+++ b/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
@@ -17,6 +17,15 @@ public class OrgException extends BusinessException {
     }
 
     public static OrgException deleteUserException(String orgName) {
-        return new OrgException(400, "다음 조직에서 마지막 루트 관리자입니다. 위임 후 계정 탈퇴 가능합니다: " + orgName);
+        return new OrgException(403, "다음 조직에서 마지막 루트 관리자입니다. 위임 후 계정 탈퇴 가능합니다: " + orgName);
     }
+
+    public static OrgException lastRootAdminRemovalNotAllowed() {
+        return new OrgException(403, "다음 조직에서 마지막 루트 관리자입니다. 위임 후 계정 탈퇴 가능합니다");
+    }
+
+    public static OrgException cannotSelfDeleteRootAdmin() {
+        return new OrgException(403, "자기 자신은 삭제할 수 없습니다. 다른 루트 관리자에게 삭제를 요청하세요.");
+    }
+
 }

--- a/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
+++ b/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
@@ -15,4 +15,8 @@ public class OrgException extends BusinessException {
     public static OrgException tooMuchRootAdminException() {
         return new OrgException(400, "루트 관리자는 최대 2명이어야 합니다.");
     }
+
+    public static OrgException deleteUserException(String orgName) {
+        return new OrgException(400, "다음 조직에서 마지막 루트 관리자입니다. 위임 후 계정 탈퇴 가능합니다: " + orgName);
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
+++ b/backend/src/main/java/com/ourhour/domain/org/exceptions/OrgException.java
@@ -1,0 +1,18 @@
+package com.ourhour.domain.org.exceptions;
+
+import com.ourhour.global.exception.BusinessException;
+
+public class OrgException extends BusinessException {
+
+    public OrgException(int status, String message) {
+        super(status, message);
+    }
+
+    public static OrgException notMuchRootAdminException() {
+        return new OrgException(400, "루트 관리자는 최소 한명 이상이어야 합니다.");
+    }
+
+    public static OrgException tooMuchRootAdminException() {
+        return new OrgException(400, "루트 관리자는 최대 2명이어야 합니다.");
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgMapper.java
@@ -1,7 +1,8 @@
 package com.ourhour.domain.org.mapper;
 
 import com.ourhour.domain.org.dto.OrgReqDTO;
-import com.ourhour.domain.org.dto.OrgResDTO;
+import com.ourhour.domain.org.dto.OrgDetailReqDTO;
+import com.ourhour.domain.org.dto.OrgDetailResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
 
 import org.mapstruct.Mapper;
@@ -11,15 +12,11 @@ import org.mapstruct.MappingTarget;
 @Mapper(componentModel = "spring")
 public interface OrgMapper {
 
-    // ReqDTO -> Entity 변환 (DB 등록)
+    // OrgReqDTO -> entity 변환
     OrgEntity toOrgEntity(OrgReqDTO orgReqDTO);
 
-    // Entity -> ResDTO 변환 (응답)
-    OrgResDTO toOrgResDTO(OrgEntity orgEntity);
 
-    // Entity -> Entity 변환 (수정)
-    @Mapping(target = "orgId", ignore = true)
-    @Mapping(target= "orgParticipantMemberEntityList", ignore = true)
-    void updateOrgEntity(@MappingTarget OrgEntity orgEntity, OrgReqDTO orgReqDTO);
+    // Entity -> ResDTO 변환 (응답)
+    OrgDetailResDTO toOrgDetailResDTO(OrgEntity orgEntity);
     
 }

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -1,16 +1,18 @@
 package com.ourhour.domain.org.mapper;
 
 import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import com.ourhour.domain.org.enums.Role;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface OrgParticipantMemberMapper {
 
-    // DTO -> Entity 변환
+    // DTO -> Entity 변환 (회사 등록)
     @Mapping(source = "orgEntity.orgId", target = "orgId")
     @Mapping(source = "orgEntity.name", target = "name")
     @Mapping(source = "orgEntity.address", target = "address")
@@ -23,4 +25,11 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgParticipantMemberEntity.role", target = "myRole")
     OrgResDTO toOrgResDTO(OrgEntity orgEntity, MemberEntity memberEntity, OrgParticipantMemberEntity orgParticipantMemberEntity);
 
+    // Entity -> DTO 변환 (구성원 권한 변경)
+    @Mapping(source = "orgParticipantMemberEntity.orgEntity.orgId", target = "orgId")
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.memberId", target = "memberId")
+    @Mapping(source = "oldRole", target = "oldRole")
+    @Mapping(source = "orgParticipantMemberEntity.role", target = "newRole")
+    @Mapping(source = "rootAdminCount", target = "rootAdminCount")
+    OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole, int rootAdminCount);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -1,0 +1,26 @@
+package com.ourhour.domain.org.mapper;
+
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.org.dto.OrgResDTO;
+import com.ourhour.domain.org.entity.OrgEntity;
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface OrgParticipantMemberMapper {
+
+    // DTO -> Entity 변환
+    @Mapping(source = "orgEntity.orgId", target = "orgId")
+    @Mapping(source = "orgEntity.name", target = "name")
+    @Mapping(source = "orgEntity.address", target = "address")
+    @Mapping(source = "orgEntity.email", target = "email")
+    @Mapping(source = "orgEntity.representativeName", target = "representativeName")
+    @Mapping(source = "orgEntity.phone", target = "phone")
+    @Mapping(source = "orgEntity.businessNumber", target = "businessNumber")
+    @Mapping(source = "orgEntity.logoImgUrl", target = "logoImgUrl")
+    @Mapping(source = "memberEntity.name", target = "memberName")
+    @Mapping(source = "orgParticipantMemberEntity.role", target = "myRole")
+    OrgResDTO toOrgResDTO(OrgEntity orgEntity, MemberEntity memberEntity, OrgParticipantMemberEntity orgParticipantMemberEntity);
+
+}

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrgParticipantMemberRepository
@@ -51,4 +52,6 @@ public interface OrgParticipantMemberRepository
     default int countRootAdmins(Long orgId) {
         return countByOrgEntity_OrgIdAndRole(orgId, Role.ROOT_ADMIN);
     }
+
+    List<OrgParticipantMemberEntity> findAllByMemberEntity_MemberIdAndStatus(Long memberId, Status status);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -4,11 +4,15 @@ import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberId;
 
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OrgParticipantMemberRepository
         extends JpaRepository<OrgParticipantMemberEntity, OrgParticipantMemberId> {
@@ -25,4 +29,26 @@ public interface OrgParticipantMemberRepository
     Page<MemberInfoResDTO> findByOrgId(@Param("orgId") Long orgId, Pageable pageable);
 
     boolean existsByOrgEntity_OrgIdAndMemberEntity_MemberId(Long orgId, Long memberId);
+
+    @Query("SELECT new com.ourhour.domain.member.dto.MemberInfoResDTO(" +
+            "m.memberId, m.name, m.email, m.phone, " +
+            "COALESCE(p.name, ''), COALESCE(d.name, ''), m.profileImgUrl) " +
+            "FROM OrgParticipantMemberEntity opm " +
+            "JOIN opm.memberEntity m " +
+            "LEFT JOIN opm.positionEntity p " +
+            "LEFT JOIN opm.departmentEntity d " +
+            "WHERE opm.orgEntity.orgId = :orgId " +
+            "AND opm.memberEntity.memberId=:memberId ")
+    MemberInfoResDTO findByOrgIdAndMemberId(Long orgId, Long memberId);
+
+
+    Optional<OrgParticipantMemberEntity> findByOrgEntity_OrgIdAndMemberEntity_MemberIdAndStatus(Long orgId, Long memberId, Status status);
+
+    // 해당 회사의 권한에 따른 멤버 수 집계
+    int countByOrgEntity_OrgIdAndRole(Long orgId, Role role);
+
+    // 권한이 루트 관리자인 멤버만 집계
+    default int countRootAdmins(Long orgId) {
+        return countByOrgEntity_OrgIdAndRole(orgId, Role.ROOT_ADMIN);
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
@@ -1,0 +1,100 @@
+package com.ourhour.domain.org.service;
+
+import com.ourhour.domain.member.dto.MemberInfoResDTO;
+import com.ourhour.domain.member.exceptions.MemberException;
+import com.ourhour.domain.org.dto.OrgMemberRoleReqDTO;
+import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import com.ourhour.domain.org.entity.OrgParticipantMemberId;
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.mapper.OrgParticipantMemberMapper;
+import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
+import com.ourhour.domain.org.repository.OrgRepository;
+import com.ourhour.global.common.dto.PageResponse;
+import com.ourhour.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ourhour.domain.org.enums.Status.ACTIVE;
+
+@Service
+@RequiredArgsConstructor
+public class OrgMemberService {
+
+    private final OrgRepository orgRepository;
+    private final OrgParticipantMemberRepository orgParticipantMemberRepository;
+    private final OrgParticipantMemberMapper orgParticipantMemberMapper;
+    private final OrgRoleGuardService orgRoleGuardService;
+
+    // 회사 구성원 목록 조회
+    public PageResponse<MemberInfoResDTO> getOrgMembers(Long orgId, Pageable pageable) {
+
+        if (orgId == null || orgId <= 0) {
+            throw BusinessException.badRequest("유효하지 않은 회사 ID입니다.");
+        }
+
+        // 회사 존재 여부 확인
+        if (!orgRepository.existsById(orgId)) {
+            throw BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId);
+        }
+
+        Page<MemberInfoResDTO> memberInfoPage = orgParticipantMemberRepository.findByOrgId(orgId, pageable);
+
+        return PageResponse.of(memberInfoPage);
+    }
+
+    // 회사 구성원 상세 조회
+    public MemberInfoResDTO getOrgMember(Long orgId, Long memberId) {
+
+        MemberInfoResDTO memberInfoResDTO = orgParticipantMemberRepository.findByOrgIdAndMemberId(orgId, memberId);
+
+        return memberInfoResDTO;
+
+    }
+
+    // 구성원 권한 변경
+    @Transactional
+    public OrgMemberRoleResDTO changeRole(Long orgId, Long memberId, OrgMemberRoleReqDTO orgMemberRoleReqDTO) {
+
+        // 대상 멤버 조회
+        OrgParticipantMemberEntity orgParticipantMemberEntity = orgParticipantMemberRepository
+                .findByOrgEntity_OrgIdAndMemberEntity_MemberIdAndStatus(orgId, memberId, ACTIVE)
+                .orElseThrow(MemberException::memberNotFoundException);
+
+        Role oldRole = orgParticipantMemberEntity.getRole();
+        Role newRole = orgMemberRoleReqDTO.getNewRole();
+        int currentRootAdminCount = orgParticipantMemberRepository.countRootAdmins(orgId);
+
+        // 동일 권한 변경일 경우 early return(정책 위반 아님)
+        if (oldRole == newRole) {
+            return orgParticipantMemberMapper.toOrgMemberRoleResDTO(orgParticipantMemberEntity, oldRole, currentRootAdminCount);
+        }
+
+        // 루트 관리자 정책 검사
+        orgRoleGuardService.assertRoleChangeAllowed(oldRole, newRole, currentRootAdminCount);
+
+        // 구성원 권한 변경
+        orgParticipantMemberEntity.changeRole(newRole);
+
+        int afterRootAdminCount = currentRootAdminCount
+                + (oldRole == Role.ROOT_ADMIN ? -1 : 0)
+                + (newRole == Role.ROOT_ADMIN ?  1 : 0);
+
+        // 엔티티 -> DTO 변환
+        OrgMemberRoleResDTO orgMemberRoleResDTO = orgParticipantMemberMapper.toOrgMemberRoleResDTO(orgParticipantMemberEntity, oldRole, afterRootAdminCount);
+
+        return orgMemberRoleResDTO;
+
+    }
+
+    // 구성원 삭제
+    @Transactional
+    public void deleteOrgMember(Long orgId, Long memberId) {
+
+
+        orgParticipantMemberRepository.deleteById(new OrgParticipantMemberId(orgId, memberId));
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgRoleGuardService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgRoleGuardService.java
@@ -3,19 +3,55 @@ package com.ourhour.domain.org.service;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.enums.Status;
+import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import static com.ourhour.domain.org.exceptions.OrgException.notMuchRootAdminException;
-import static com.ourhour.domain.org.exceptions.OrgException.tooMuchRootAdminException;
+import static com.ourhour.domain.org.exceptions.OrgException.*;
 
 @Service
 @RequiredArgsConstructor
 public class OrgRoleGuardService {
 
-    public void checkCanWithDraw(List<MemberEntity> memberEntityList) {
+    private final OrgParticipantMemberRepository orgParticipantMemberRepository;
+
+    // 계정 탈퇴 예외 처리
+    public void assertNotLastRootAdminAcrossAll(List<MemberEntity> memberEntityList) {
+
+        // 소속 조직이 없으면 바로 탈퇴 가능
+        if (memberEntityList == null || memberEntityList.isEmpty()) {
+            return;
+        }
+
+        List<String> blockedOrgList = new ArrayList<>();
+
+        // 해당 멤버가 소속되어 있는 모든 회사 참여 정보 조회 (ACTIVE 상태인 경우만)
+        for (MemberEntity member : memberEntityList) {
+            List<OrgParticipantMemberEntity> orgParticipantMemberEntityList
+                    = orgParticipantMemberRepository.findAllByMemberEntity_MemberIdAndStatus(member.getMemberId(), Status.ACTIVE);
+
+            // 루트 관리자가 하나인 회사가 하나라도 존재하는 경우 계정 탈퇴 불가
+            for (OrgParticipantMemberEntity opm : orgParticipantMemberEntityList) {
+                if (opm.getRole() != Role.ROOT_ADMIN) continue;
+
+                // 루트 관리자인 경우 해당 회사의 루트 관리자 수 조회
+                Long orgId = opm.getOrgEntity().getOrgId();
+                int rootAdminCount = orgParticipantMemberRepository.countRootAdmins(orgId);
+
+                if (rootAdminCount <= 1) {
+                    String orgName = opm.getOrgEntity().getName();
+                    blockedOrgList.add(orgName);
+                }
+            }
+        }
+
+        if (!blockedOrgList.isEmpty()) {
+            throw deleteUserException(String.join(", ", blockedOrgList));
+        }
 
     }
 

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
@@ -2,20 +2,31 @@ package com.ourhour.domain.org.service;
 
 import java.util.List;
 
+import com.ourhour.domain.auth.exception.AuthException;
 import com.ourhour.domain.member.dto.MemberInfoResDTO;
+import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
+import com.ourhour.domain.org.dto.OrgDetailReqDTO;
+import com.ourhour.domain.org.dto.OrgDetailResDTO;
 import com.ourhour.domain.org.dto.OrgReqDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
+import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberId;
+import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.mapper.OrgMapper;
+import com.ourhour.domain.org.mapper.OrgParticipantMemberMapper;
 import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.domain.org.repository.OrgRepository;
 import com.ourhour.domain.project.dto.ProjectNameResDTO;
 import com.ourhour.domain.project.repository.ProjectParticipantRepository;
+import com.ourhour.domain.user.entity.UserEntity;
+import com.ourhour.domain.user.repository.UserRepository;
 import com.ourhour.global.common.dto.PageResponse;
 import com.ourhour.global.exception.BusinessException;
 
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.util.UserContextHolder;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -32,48 +43,51 @@ public class OrgService {
     private final MemberRepository memberRepository;
     private final OrgParticipantMemberRepository orgParticipantMemberRepository;
     private final ProjectParticipantRepository projectParticipantRepository;
+    private final UserRepository userRepository;
+    private final OrgParticipantMemberMapper orgParticipantMemberMapper;
 
     @Transactional
     public OrgResDTO registerOrg(OrgReqDTO orgReqDTO) {
 
+        // 해당 회사를 등록한 유저 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long userId = claims.getUserId();
+
+        // 회사를 등록한 사용자 조회
+        UserEntity userEntity = userRepository.findByUserIdAndIsDeletedFalse(userId)
+                .orElseThrow(AuthException::userNotFoundException);
+
         // OrgReqDTO에서 OrgEntity로 변환
         OrgEntity orgReqEntity = orgMapper.toOrgEntity(orgReqDTO);
 
-        // 데이터베이스에 등록 - 회사 생성
+        // 회사 등록
         OrgEntity orgEntity = orgRepository.save(orgReqEntity);
 
-        // TODO: 루트 관리자 권한 추가 예정
-        /*
-         * // 루트 관리자가 될 MemberEntity 조회
-         * MemberEntity memberEntity = memberRepository.findById(memberId)
-         * .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 ID 입니다: " +
-         * memberId));
-         * 
-         * // 해당 회사에 대한 루트 관리자 권한 생성
-         * OrgParticipantMemberId orgParticipantMemberId = new
-         * OrgParticipantMemberId(orgEntity.getOrgId(), memberEntity.getMemberId());
-         * OrgParticipantMemberEntity orgParticipantMemberEntity =
-         * OrgParticipantMemberEntity.builder()
-         * .orgParticipantMemberId(orgParticipantMemberId)
-         * .orgEntity(orgEntity)
-         * .memberEntity(memberEntity)
-         * .departmentEntity(null)
-         * .positionEntity(null)
-         * .role(Role.ROOT_ADMIN)
-         * .build();
-         * 
-         * // 데이터베이스에 등록 - 해당 회사의 루트 관리자 권한
-         * orgParticipantMemberRepository.save(orgParticipantMemberEntity);
-         */
+        // 해당 회사를 등록한 유저, 멤버 자동 등록
+        MemberEntity memberEntity = MemberEntity.builder()
+                .userEntity(userEntity)
+                .name(orgReqDTO.getMemberName())
+                .email(userEntity.getEmail())
+                .build();
+        memberRepository.save(memberEntity);
+
+        // 해당 회사의 루트 관리자 권한 부여
+        OrgParticipantMemberEntity orgParticipantMemberEntity = OrgParticipantMemberEntity.builder()
+                .orgEntity(orgEntity)
+                .memberEntity(memberEntity)
+                .role(Role.ROOT_ADMIN)
+                .build();
+        orgParticipantMemberRepository.save(orgParticipantMemberEntity);
 
         // 응답 DTO로 변환
-        OrgResDTO orgResDTO = orgMapper.toOrgResDTO(orgEntity);
+        OrgResDTO orgResDTO = orgParticipantMemberMapper.toOrgResDTO(orgEntity, memberEntity, orgParticipantMemberEntity);
 
         return orgResDTO;
+
     }
 
     // 회사 정보 조회
-    public OrgResDTO getOrgInfo(Long orgId) {
+    public OrgDetailResDTO getOrgInfo(Long orgId) {
 
         if (orgId <= 0) {
             throw BusinessException.badRequest("유효하지 않은 회사 ID입니다.");
@@ -82,14 +96,14 @@ public class OrgService {
         OrgEntity orgEntity = orgRepository.findById(orgId)
                 .orElseThrow(() -> BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId));
 
-        OrgResDTO orgResDTO = orgMapper.toOrgResDTO(orgEntity);
+        OrgDetailResDTO orgDetailResDTO = orgMapper.toOrgDetailResDTO(orgEntity);
 
-        return orgResDTO;
+        return orgDetailResDTO;
     }
 
     // 회사 정보 수정
     @Transactional
-    public OrgResDTO updateOrg(Long orgId, OrgReqDTO orgReqDTO) {
+    public OrgDetailResDTO updateOrg(Long orgId, OrgDetailReqDTO orgDetailReqDTO) {
 
         if (orgId <= 0) {
             throw BusinessException.badRequest("유효하지 않은 회사 ID입니다.");
@@ -98,11 +112,12 @@ public class OrgService {
         OrgEntity orgEntity = orgRepository.findById(orgId)
                 .orElseThrow(() -> BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId));
 
-        orgMapper.updateOrgEntity(orgEntity, orgReqDTO);
+        orgEntity.updateInfo(orgDetailReqDTO);
 
         OrgEntity updatedOrgEntity = orgRepository.save(orgEntity);
 
-        return orgMapper.toOrgResDTO(updatedOrgEntity);
+        return orgMapper.toOrgDetailResDTO(updatedOrgEntity);
+
     }
 
     // 회사 구성원 목록 조회
@@ -121,6 +136,9 @@ public class OrgService {
 
         return PageResponse.of(memberInfoPage);
     }
+
+    // 회사 구성원 상세 조회
+
 
     // 구성원 삭제
     @Transactional

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
@@ -3,11 +3,11 @@ package com.ourhour.domain.org.service;
 import java.util.List;
 
 import com.ourhour.domain.auth.exception.AuthException;
-import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.org.dto.OrgDetailReqDTO;
 import com.ourhour.domain.org.dto.OrgDetailResDTO;
+
 import com.ourhour.domain.org.dto.OrgReqDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
@@ -22,17 +22,16 @@ import com.ourhour.domain.project.dto.ProjectNameResDTO;
 import com.ourhour.domain.project.repository.ProjectParticipantRepository;
 import com.ourhour.domain.user.entity.UserEntity;
 import com.ourhour.domain.user.repository.UserRepository;
-import com.ourhour.global.common.dto.PageResponse;
+
 import com.ourhour.global.exception.BusinessException;
 
 import com.ourhour.global.jwt.dto.Claims;
 import com.ourhour.global.jwt.util.UserContextHolder;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -118,32 +117,6 @@ public class OrgService {
 
         return orgMapper.toOrgDetailResDTO(updatedOrgEntity);
 
-    }
-
-    // 회사 구성원 목록 조회
-    public PageResponse<MemberInfoResDTO> getOrgMembers(Long orgId, Pageable pageable) {
-
-        if (orgId == null || orgId <= 0) {
-            throw BusinessException.badRequest("유효하지 않은 회사 ID입니다.");
-        }
-
-        // 회사 존재 여부 확인
-        if (!orgRepository.existsById(orgId)) {
-            throw BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId);
-        }
-
-        Page<MemberInfoResDTO> memberInfoPage = orgParticipantMemberRepository.findByOrgId(orgId, pageable);
-
-        return PageResponse.of(memberInfoPage);
-    }
-
-    // 회사 구성원 상세 조회
-
-
-    // 구성원 삭제
-    @Transactional
-    public void deleteOrgMember(Long orgId, Long memberId) {
-        orgParticipantMemberRepository.deleteById(new OrgParticipantMemberId(orgId, memberId));
     }
 
     // 회사 삭제

--- a/backend/src/main/java/com/ourhour/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/user/repository/UserRepository.java
@@ -11,7 +11,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByEmailAndIsDeletedFalse(@NotBlank(message = "이메일은 필수입니다.") @Email String email);
 
-    Optional<UserEntity> findByUserId(Long userId);
+    Optional<UserEntity> findByUserIdAndIsDeletedFalse(Long userId);
 
     boolean existsByEmailAndIsDeletedFalse(@NotBlank(message = "이메일은 필수입니다.") @Email String email);
 }

--- a/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
@@ -77,7 +77,8 @@ public class UserService {
         // UserEntity와 연결된 모든 MemberEntity 조회
         List<MemberEntity> memberEntityList = memberRepository.findByUserEntity_UserId(userId);
 
-        orgRoleGuardService.checkCanWithDraw(memberEntityList);
+        // 루트 관리자 정책 확인
+        orgRoleGuardService.assertNotLastRootAdminAcrossAll(memberEntityList);
 
         // soft delete 처리
         userEntity.markAsDeleted();

--- a/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.enums.Role;
+import com.ourhour.domain.org.enums.Status;
 import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.domain.org.service.OrgRoleGuardService;
 import com.ourhour.domain.user.dto.PwdChangeReqDTO;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,7 @@ public class UserService {
     private final EmailVerificationRepository emailVerificationRepository;
     private final MemberRepository memberRepository;
     private final OrgRoleGuardService orgRoleGuardService;
+    private final OrgParticipantMemberRepository orgParticipantMemberRepository;
 
     // 비밀번호 변경
     @Transactional
@@ -69,11 +72,9 @@ public class UserService {
     public void deleteUser(PwdVerifyReqDTO pwdVerifyReqDTO) {
 
         String pwd = pwdVerifyReqDTO.getPassword();
-
         UserEntity userEntity = passwordVerifier.verifyPassword(pwd);
 
         Long userId = userEntity.getUserId();
-
         // UserEntity와 연결된 모든 MemberEntity 조회
         List<MemberEntity> memberEntityList = memberRepository.findByUserEntity_UserId(userId);
 
@@ -82,6 +83,14 @@ public class UserService {
 
         // soft delete 처리
         userEntity.markAsDeleted();
+
+        // 탈퇴한 사용자가 속한 모든 회사의 활성상태 INACTIVE 처리
+        if (!memberEntityList.isEmpty()) {
+            LocalDateTime now = LocalDateTime.now();
+
+            orgParticipantMemberRepository
+                    .updateDeactivateAllMembers(memberEntityList, Status.INACTIVE, now, Status.ACTIVE);
+        }
 
         // 탈퇴한 사용자 익명 처리
         anonymizeUserService.anonymizeUser(memberEntityList);

--- a/backend/src/main/java/com/ourhour/domain/user/util/PasswordVerifier.java
+++ b/backend/src/main/java/com/ourhour/domain/user/util/PasswordVerifier.java
@@ -21,14 +21,11 @@ public class PasswordVerifier {
 
     public UserEntity verifyPassword(String currentPwd) {
 
-        // 예외 발생: 로그인 토큰 없음 또는 만료됨
-        Claims claims = UserContextHolder.get();
-        if (claims == null) {
-            throw unauthorizedException();
-        }
-
         // 사용자 조회
-        UserEntity userEntity = userRepository.findByUserId(claims.getUserId())
+        Claims claims = UserContextHolder.get();
+        Long userId = claims.getUserId();
+
+        UserEntity userEntity = userRepository.findByUserIdAndIsDeletedFalse(userId)
                 .orElseThrow(AuthException::userNotFoundException);
 
         // 예외 발생: 현재 비밀번호 불일치

--- a/backend/src/main/resources/db/migration/V7__add_columns_opm_add_table_oib.sql
+++ b/backend/src/main/resources/db/migration/V7__add_columns_opm_add_table_oib.sql
@@ -5,9 +5,6 @@ ALTER TABLE `tbl_org_participant_member`
     ADD COLUMN `status` ENUM('ACTIVE','INACTIVE') NOT NULL DEFAULT 'ACTIVE' AFTER `role`,
   ADD COLUMN `joined_at` DATETIME(6) NULL AFTER `status`,
   ADD COLUMN `left_at` DATETIME(6) NULL AFTER `joined_at`,
-  ADD COLUMN `left_by_member_id` BIGINT NULL AFTER `left_at`,
-  ADD CONSTRAINT `FK_opm_left_by_member`
-    FOREIGN KEY (`left_by_member_id`) REFERENCES `tbl_member`(`member_id`) ON DELETE SET NULL,
   ADD INDEX `IDX_opm_org_status` (`org_id`, `status`);
 ;
 

--- a/backend/src/main/resources/db/migration/V7__add_columns_opm_add_table_oib.sql
+++ b/backend/src/main/resources/db/migration/V7__add_columns_opm_add_table_oib.sql
@@ -1,0 +1,62 @@
+-- =========================================================
+-- 1) org_participant_member 확장
+-- =========================================================
+ALTER TABLE `tbl_org_participant_member`
+    ADD COLUMN `status` ENUM('ACTIVE','INACTIVE') NOT NULL DEFAULT 'ACTIVE' AFTER `role`,
+  ADD COLUMN `joined_at` DATETIME(6) NULL AFTER `status`,
+  ADD COLUMN `left_at` DATETIME(6) NULL AFTER `joined_at`,
+  ADD COLUMN `left_by_member_id` BIGINT NULL AFTER `left_at`,
+  ADD CONSTRAINT `FK_opm_left_by_member`
+    FOREIGN KEY (`left_by_member_id`) REFERENCES `tbl_member`(`member_id`) ON DELETE SET NULL,
+  ADD INDEX `IDX_opm_org_status` (`org_id`, `status`);
+;
+
+-- =========================================================
+-- 2) 초대 배치 테이블 생성
+-- =========================================================
+CREATE TABLE `tbl_org_invitation_batch` (
+                                            `batch_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                            `org_id` BIGINT NOT NULL,
+                                            `inviter_member_id` BIGINT NOT NULL,
+                                            `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                                            CONSTRAINT `FK_batch_org`
+                                                FOREIGN KEY (`org_id`) REFERENCES `tbl_org`(`org_id`) ON DELETE CASCADE,
+                                            CONSTRAINT `FK_batch_inviter_member`
+                                                FOREIGN KEY (`inviter_member_id`) REFERENCES `tbl_member`(`member_id`) ON DELETE CASCADE
+)
+;
+
+-- =========================================================
+-- 3) 초대 테이블 ENUM 축소 준비 (CANCELLED → EXPIRED)
+--    기존 데이터 중 CANCELLED 값이 있다면 EXPIRED로 대체
+-- =========================================================
+UPDATE `tbl_org_invitations`
+SET `status` = 'EXPIRED'
+WHERE `status` = 'CANCELLED';
+;
+
+-- =========================================================
+-- 4) 초대 테이블 구조 변경
+-- =========================================================
+ALTER TABLE `tbl_org_invitations`
+DROP INDEX `invited_email`,
+DROP INDEX `invited_code`,
+DROP COLUMN `invited_code`,
+ADD COLUMN `batch_id` BIGINT NULL AFTER `inviter_member_id`,
+ADD COLUMN `role` ENUM('ROOT_ADMIN','ADMIN', 'MEMBER', 'GUEST') NOT NULL DEFAULT 'MEMBER' AFTER `invited_email`,
+MODIFY COLUMN `invited_email` VARCHAR(100) NOT NULL,
+MODIFY COLUMN `status` ENUM('PENDING','ACCEPTED','EXPIRED') NOT NULL DEFAULT 'PENDING',
+ADD CONSTRAINT `FK_invitation_batch` FOREIGN KEY (`batch_id`) REFERENCES `tbl_org_invitation_batch`(`batch_id`) ON DELETE SET NULL;
+;
+
+-- =========================================================
+-- 5) role ENUM에 'GUEST' 추가
+-- =========================================================
+ALTER TABLE `tbl_org_participant_member`
+MODIFY COLUMN `role` ENUM('ROOT_ADMIN','ADMIN','MEMBER','GUEST') NOT NULL DEFAULT 'MEMBER';
+;
+INSERT INTO `tbl_org_participant_member` (
+    `org_id`, `member_id`, `dept_id`, `position_id`, `role`
+) VALUES (
+    1, 5, null, null, 'ROOT_ADMIN'
+)


### PR DESCRIPTION
## 📌 제목
feat: 회사 등록 시 멤버 자동 등록 및 루트 관리자 권한 부여 기능 추가, 회사 관련 API 권한 부여
feat(be): 구성원-회사 서비스 및 컨트롤러 분리, 구성원 상세 조회, 권한 변경 추가
feat(be): 계정 탈퇴 시 루트 관리자 정책 조건 예외 처리 추가
feat(be): 구성원 삭제 시 루트 관리자 정책 제한 조건 추가 및 soft delete로 변경

## 🔗 관련 이슈
- Close #108 #33 #35 #40 #7 #9 #65 

## ✅ 작업 내용
- 회사 등록 시 해당 회사의 멤버로 자동 등록 및 루트 관리자 권한 부여
- 회사 관련 모든 API 에 인가 적용
- 구성원-회사 서비스 및 컨트롤러 분리
- 구성원 상세 조회 API 추가
- 구성원 권한 변경 API 추가 - 루트 관리자 정책 부여
- 계정 탈퇴 API 구현 - 루트 관리자 정책 부여
- 구성원 삭제 API 변경 - 루트 관리자 정책 부여 및 soft delete로 변경

## 📝 기타 참고 사항
- 루트 관리자 정책 : 루트 관리자 최소 1명, 최대 2명
- 루트 관리자 정책은 OrgRoleServiceGaurd에서 다루고 있습니다.
