### PR TITLE
feat(be): 회사 멤버 조회 API 추가 및 채팅방 컬럼 수정

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/entity/ChatRoomEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/entity/ChatRoomEntity.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -28,6 +29,7 @@ public class ChatRoomEntity {
     @Enumerated(EnumType.STRING)
     private TagColor color;
 
+    @CreationTimestamp
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -24,6 +24,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/organizations")
 @RequiredArgsConstructor
@@ -44,6 +46,16 @@ public class OrgMemberController {
         PageResponse<MemberInfoResDTO> response = orgMemberService.getOrgMembers(orgId, pageable);
 
         return ResponseEntity.ok(ApiResponse.success(response, "팀 구성원 조회에 성공하였습니다."));
+    }
+
+    @OrgAuth
+    @GetMapping("/{orgId}/members/all")
+    public ResponseEntity<ApiResponse<List<MemberInfoResDTO>>> getAllOrgMembers(
+            @OrgId @PathVariable @Min(value = 1, message = "팀 ID는 1 이상이어야 합니다.") Long orgId) {
+
+        List<MemberInfoResDTO> response = orgMemberService.getAllOrgMembers(orgId);
+
+        return ResponseEntity.ok(ApiResponse.success(response, "전체 구성원 조회에 성공하였습니다."));
     }
 
     // 구성원 상세 조회

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -7,6 +7,7 @@ import com.ourhour.domain.org.entity.OrgParticipantMemberId;
 
 import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.enums.Status;
+import com.ourhour.global.common.dto.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -78,4 +79,15 @@ public interface OrgParticipantMemberRepository
 
     // 조직 내 활성 루트 관리자 수 조회
     int countByOrgEntity_OrgIdAndRoleAndStatus(Long orgId, Role role, Status status);
+
+    @Query("SELECT new com.ourhour.domain.member.dto.MemberInfoResDTO(" +
+            "m.memberId, m.name, m.email, m.phone, " +
+            "COALESCE(p.name, ''), COALESCE(d.name, ''), m.profileImgUrl) " +
+            "FROM OrgParticipantMemberEntity opm " +
+            "JOIN opm.memberEntity m " +
+            "LEFT JOIN opm.positionEntity p " +
+            "LEFT JOIN opm.departmentEntity d " +
+            "WHERE opm.orgEntity.orgId = :orgId " +
+            "ORDER BY m.memberId ASC")
+   List<MemberInfoResDTO> findAllByOrgEntity_OrgId(Long orgId);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgRepository.java
@@ -1,9 +1,13 @@
 package com.ourhour.domain.org.repository;
 
+import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 public interface OrgRepository extends JpaRepository<OrgEntity, Long> {
 
+    List<MemberInfoResDTO> findByOrgId(Long orgId);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -107,5 +108,21 @@ public class OrgMemberService {
         orgParticipantMemberEntity.changeStatus(Status.INACTIVE);
         orgParticipantMemberEntity.markLeftNow();
 
+    }
+
+    public List<MemberInfoResDTO> getAllOrgMembers(Long orgId) {
+
+        if (orgId == null || orgId <= 0) {
+            throw BusinessException.badRequest("유효하지 않은 회사 ID입니다.");
+        }
+
+        // 회사 존재 여부 확인
+        if (!orgRepository.existsById(orgId)) {
+            throw BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId);
+        }
+
+        List<MemberInfoResDTO> memberInfoResDTOList = orgParticipantMemberRepository.findAllByOrgEntity_OrgId(orgId);
+
+        return memberInfoResDTOList;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #111

## ✅ 작업 내용
- 회사 멤버를 페이지네이션 없이 전체 조회하기 위한 API를 추가하였습니다.[(OUR-ORG-013 임시)]
  - 추후 리팩토링 시 삭제 예정입니다. 
- `ChatRoomEntity`의 `createdAt`컬럼에 생성일시 값이 자동으로 추가되도록 `CreattionTimeStamp` 어노테이션을 추가하였습니다.

## 📝 기타 참고 사항
- x

