### PR TITLE
feat(be): 회사 내 나의 개인정보 상세 조회 및 수정 API 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.ourhour.domain.member.controller;
 
 import com.ourhour.domain.member.dto.MemberOrgDetailResDTO;
 import com.ourhour.domain.member.dto.MemberOrgSummaryResDTO;
+import com.ourhour.domain.member.dto.MyMemberInfoReqDTO;
 import com.ourhour.domain.member.dto.MyMemberInfoResDTO;
 import com.ourhour.domain.member.service.MemberService;
 import com.ourhour.domain.org.entity.OrgEntity;
@@ -24,6 +25,8 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Max;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -96,12 +99,26 @@ public class MemberController {
     }
 
     // 회사 내 개인 정보 조회
+    @OrgAuth
     @GetMapping("/organizations/{orgId}/me")
     public ResponseEntity<ApiResponse<MyMemberInfoResDTO>> findMyMemberInfoInOrg(@OrgId @PathVariable Long orgId) {
 
         MyMemberInfoResDTO memberInfoResDTO = memberService.findMyMemberInfoInOrg(orgId);
 
         ApiResponse<MyMemberInfoResDTO> apiResponse = ApiResponse.success(memberInfoResDTO, "회사 내 개인 정보 조회에 성공하였습니다.");
+
+        return ResponseEntity.ok(apiResponse);
+
+    }
+
+    // 회사 내 개인 정보 수정
+    @OrgAuth
+    @PostMapping("/organizations/{orgId}/me")
+    public ResponseEntity<ApiResponse<MyMemberInfoResDTO>> updateMyMemberInfoInOrg(@OrgId @PathVariable Long orgId, @RequestBody MyMemberInfoReqDTO myMemberInfoReqDTO) {
+
+        MyMemberInfoResDTO memberInfoResDTO = memberService.updateMyMemberInfoInOrg(orgId, myMemberInfoReqDTO);
+
+        ApiResponse<MyMemberInfoResDTO> apiResponse = ApiResponse.success(memberInfoResDTO, "회사 내 개인 정보 수정에 성공하였습니다.");
 
         return ResponseEntity.ok(apiResponse);
 

--- a/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
@@ -2,11 +2,14 @@ package com.ourhour.domain.member.controller;
 
 import com.ourhour.domain.member.dto.MemberOrgDetailResDTO;
 import com.ourhour.domain.member.dto.MemberOrgSummaryResDTO;
+import com.ourhour.domain.member.dto.MyMemberInfoResDTO;
 import com.ourhour.domain.member.service.MemberService;
 import com.ourhour.domain.org.entity.OrgEntity;
 import com.ourhour.domain.org.repository.OrgRepository;
 import com.ourhour.global.common.dto.ApiResponse;
 import com.ourhour.global.exception.BusinessException;
+import com.ourhour.global.jwt.annotation.OrgAuth;
+import com.ourhour.global.jwt.annotation.OrgId;
 import com.ourhour.global.jwt.util.UserContextHolder;
 import com.ourhour.global.jwt.dto.Claims;
 import com.ourhour.global.common.dto.PageResponse;
@@ -66,8 +69,9 @@ public class MemberController {
     }
 
     // 본인이 속한 회사 상세 조회
+    @OrgAuth
     @GetMapping("/organizations/{orgId}")
-    public ResponseEntity<ApiResponse<MemberOrgDetailResDTO>> findOrgDetailByMemberIdAndOrgId(@PathVariable Long orgId) {
+    public ResponseEntity<ApiResponse<MemberOrgDetailResDTO>> findOrgDetailByMemberIdAndOrgId(@OrgId @PathVariable Long orgId) {
 
         Claims claims = UserContextHolder.get();
 
@@ -89,6 +93,18 @@ public class MemberController {
         MemberOrgDetailResDTO memberOrgDetailResDTO = memberService.findOrgDetailByMemberIdAndOrgId(memberId, orgEntity.getOrgId());
 
         return ResponseEntity.ok(ApiResponse.success(memberOrgDetailResDTO, "본인이 속한 회사 상세 조회에 성공했습니다."));
+    }
+
+    // 회사 내 개인 정보 조회
+    @GetMapping("/organizations/{orgId}/me")
+    public ResponseEntity<ApiResponse<MyMemberInfoResDTO>> findMyMemberInfoInOrg(@OrgId @PathVariable Long orgId) {
+
+        MyMemberInfoResDTO memberInfoResDTO = memberService.findMyMemberInfoInOrg(orgId);
+
+        ApiResponse<MyMemberInfoResDTO> apiResponse = ApiResponse.success(memberInfoResDTO, "회사 내 개인 정보 조회에 성공하였습니다.");
+
+        return ResponseEntity.ok(apiResponse);
+
     }
 
 

--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoReqDTO.java
@@ -1,26 +1,19 @@
 package com.ourhour.domain.member.dto;
 
-import com.ourhour.domain.org.enums.Role;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class MyMemberInfoResDTO {
+public class MyMemberInfoReqDTO {
 
-
-    private Long memberId;
-    private Long orgId;
     private String name;
     private String phone;
     private String email;
     private String profileImgUrl;
     private String deptName;
     private String positionName;
-    private Role role;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
@@ -1,0 +1,26 @@
+package com.ourhour.domain.member.dto;
+
+import com.ourhour.domain.org.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyMemberInfoResDTO {
+
+    private Long userId;
+    private Long memberId;
+    private Long orgId;
+    private String name;
+    private String phone;
+    private String email;
+    private String profileImgUrl;
+    private String deptName;
+    private String positionName;
+    private Role role;
+
+}

--- a/backend/src/main/java/com/ourhour/domain/member/entity/MemberEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/member/entity/MemberEntity.java
@@ -43,4 +43,11 @@ public class MemberEntity {
         this.name = "Anonymous_Name" + suffix;
         this.email = "Anonymous_Email" + suffix;
     }
+
+    public void changeMyMemberInfo(String name, String phone, String email, String profileImgUrl) {
+        if (name != null && !name.isBlank()) this.name = name;
+        if (phone != null) this.phone = phone;
+        if (email != null) this.email = email;
+        if (profileImgUrl != null) this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/ourhour/domain/member/service/MemberService.java
@@ -1,11 +1,17 @@
 package com.ourhour.domain.member.service;
 
+import com.ourhour.domain.member.dto.MyMemberInfoResDTO;
+import com.ourhour.domain.member.exceptions.MemberException;
+import com.ourhour.domain.org.enums.Status;
+import com.ourhour.domain.org.mapper.OrgParticipantMemberMapper;
+import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.global.exception.BusinessException;
 import com.ourhour.domain.member.dto.MemberOrgDetailResDTO;
 import com.ourhour.domain.member.dto.MemberOrgSummaryResDTO;
 import com.ourhour.domain.member.mapper.MemberOrgMapper;
 import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import com.ourhour.global.jwt.util.UserContextHolder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +27,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberOrgMapper memberOrgMapper;
+    private final OrgParticipantMemberRepository orgParticipantMemberRepository;
+    private final OrgParticipantMemberMapper orgParticipantMemberMapper;
 
     public MemberOrgSummaryResDTO findOrgSummaryByMemberId(Long memberId) {
         OrgParticipantMemberEntity orgParticipantMemberEntity = memberRepository.findOrgByMemberId(memberId);
@@ -67,4 +75,20 @@ public class MemberService {
         return memberOrgDetailResDTO;
 
     }
+
+    // 회사 내 개인정보 상세 조회
+    public MyMemberInfoResDTO findMyMemberInfoInOrg(Long orgId) {
+
+        // 해당 회사 내에 내 정보가 있고 활성 상태인지 조회
+        Long userId = UserContextHolder.get().getUserId();
+        OrgParticipantMemberEntity opm = orgParticipantMemberRepository
+                .findByOrgEntity_OrgIdAndMemberEntity_UserEntity_UserIdAndStatus(orgId, userId, Status.ACTIVE)
+                .orElseThrow(MemberException::memberNotFoundException);
+
+        MyMemberInfoResDTO memberInfoResDTO = orgParticipantMemberMapper.toMyMemberInfoResDTO(userId, opm);
+
+        return memberInfoResDTO;
+
+    }
+
 }

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -97,17 +97,4 @@ public class OrgMemberController {
 
     }
 
-    // 회사 나가기
-    @OrgAuth
-    @DeleteMapping("/{orgId}/members/me")
-    public ResponseEntity<ApiResponse<Void>> exitOrg(@OrgId @PathVariable Long orgId) {
-
-        orgMemberService.exitOrg(orgId);
-
-        ApiResponse<Void> apiResponse = ApiResponse.success(null, "회사를 성공적으로 나갔습니다.");
-
-        return ResponseEntity.ok(apiResponse);
-
-    }
-
 }

--- a/backend/src/main/java/com/ourhour/domain/org/entity/DepartmentEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/DepartmentEntity.java
@@ -23,4 +23,7 @@ public class DepartmentEntity {
 
     private String name;
 
+    public void changeDept(String deptName) {
+        if (deptName != null) this.name = deptName;
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/entity/PositionEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/org/entity/PositionEntity.java
@@ -22,4 +22,8 @@ public class PositionEntity {
     private List<OrgParticipantMemberEntity> orgParticipantMemberEntityList = new ArrayList<>();
 
     private String name;
+
+    public void changePosition(String positionName) {
+        if (positionName!=null) this.name =positionName;
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.org.mapper;
 
+import com.ourhour.domain.member.dto.MyMemberInfoResDTO;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
@@ -32,4 +33,18 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgParticipantMemberEntity.role", target = "newRole")
     @Mapping(source = "rootAdminCount", target = "rootAdminCount")
     OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole, int rootAdminCount);
+
+
+    // Enity -> DTO 변화 (회사 내 개인정보 조회)
+    @Mapping(source = "userId", target = "userId")
+    @Mapping(source = "opm.memberEntity.memberId", target = "memberId")
+    @Mapping(source = "opm.orgEntity.orgId", target = "orgId")
+    @Mapping(source = "opm.memberEntity.name", target="name")
+    @Mapping(source = "opm.memberEntity.phone", target="phone")
+    @Mapping(source = "opm.memberEntity.email", target="email")
+    @Mapping(source = "opm.memberEntity.profileImgUrl", target="profileImgUrl")
+    @Mapping(source = "opm.departmentEntity.name", target="deptName")
+    @Mapping(source = "opm.positionEntity.name", target="positionName")
+    @Mapping(source = "opm.role", target="role")
+    MyMemberInfoResDTO toMyMemberInfoResDTO(Long userId, OrgParticipantMemberEntity opm);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.org.mapper;
 
+import com.ourhour.domain.member.dto.MyMemberInfoReqDTO;
 import com.ourhour.domain.member.dto.MyMemberInfoResDTO;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
@@ -36,7 +37,6 @@ public interface OrgParticipantMemberMapper {
 
 
     // Enity -> DTO 변화 (회사 내 개인정보 조회)
-    @Mapping(source = "userId", target = "userId")
     @Mapping(source = "opm.memberEntity.memberId", target = "memberId")
     @Mapping(source = "opm.orgEntity.orgId", target = "orgId")
     @Mapping(source = "opm.memberEntity.name", target="name")
@@ -46,5 +46,6 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "opm.departmentEntity.name", target="deptName")
     @Mapping(source = "opm.positionEntity.name", target="positionName")
     @Mapping(source = "opm.role", target="role")
-    MyMemberInfoResDTO toMyMemberInfoResDTO(Long userId, OrgParticipantMemberEntity opm);
+    MyMemberInfoResDTO toMyMemberInfoResDTO(OrgParticipantMemberEntity opm);
+
 }


### PR DESCRIPTION
## 📌 제목
feat(be): 회사 내 나의 개인정보 상세 조회 및 수정 API 구현

## 🔗 관련 이슈
- Close #128 

## ✅ 작업 내용
- 회사 내 나의 개인 정보 조회 API 구현
- 회사 내의 나의 개인 정보 수정 API 구현

## 📝 기타 참고 사항
- 부서 및 직책 관련 API가 없어서 회원 정보 수정에서는 부서, 직책 변경이 아직 불가능합니다.
- 추후에 업데이트 예정

