### PR TITLE
feat(fe): 회사 정보 페이지 ui 구현 및 api 연동

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/member/dto/MemberInfoResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MemberInfoResDTO.java
@@ -15,8 +15,9 @@ public class MemberInfoResDTO {
     private String name;
     private String email;
     private String phone;
-    private String positionName;
-    private String deptName;
+    private String positionName;  
+    private String deptName;        
     private String profileImgUrl;
+    private String role;             
     
 }

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgController.java
@@ -46,7 +46,7 @@ public class OrgController {
     // 회사 정보 수정
     @OrgAuth(accessLevel = Role.ROOT_ADMIN)
     @PutMapping("/{orgId}")
-    public ResponseEntity<ApiResponse<OrgDetailResDTO>> updateOrg(@PathVariable Long orgId,
+    public ResponseEntity<ApiResponse<OrgDetailResDTO>> updateOrg(@OrgId @PathVariable Long orgId,
             @Valid @RequestBody OrgDetailReqDTO orgDetailReqDTO) {
         OrgDetailResDTO orgDetailResDTO = orgService.updateOrg(orgId, orgDetailReqDTO);
 

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -38,10 +38,10 @@ public class OrgMemberController {
     @GetMapping("/{orgId}/members")
     public ResponseEntity<ApiResponse<PageResponse<MemberInfoResDTO>>> getOrgMembers(
             @OrgId @PathVariable @Min(value = 1, message = "팀 ID는 1 이상이어야 합니다.") Long orgId,
-            @RequestParam(defaultValue = "1") @Min(value = 0, message = "페이지 번호는 1 이상이어야 합니다.") int currentPage,
+            @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지 번호는 0 이상이어야 합니다.") int currentPage,
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.") int size) {
 
-        Pageable pageable = PageRequest.of(currentPage, size);
+        Pageable pageable = PageRequest.of(currentPage - 1, size);
 
         PageResponse<MemberInfoResDTO> response = orgMemberService.getOrgMembers(orgId, pageable);
 

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgDetailReqDTO.java
@@ -32,7 +32,10 @@ public class OrgDetailReqDTO {
 
     private String businessNumber;
 
-    @URL
+    @Pattern(
+            regexp = "^(https?://.*|data:image/(png|jpg|jpeg|gif|svg\\+xml);base64,.*|/images/.*)$",
+            message = "올바른 URL, Base64 이미지 데이터, 또는 기존 이미지 경로여야 합니다"
+    )
     private String logoImgUrl;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgMemberRoleResDTO.java
@@ -1,6 +1,5 @@
 package com.ourhour.domain.org.dto;
 
-import com.ourhour.domain.org.enums.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,8 +12,8 @@ public class OrgMemberRoleResDTO {
 
     private Long orgId;
     private Long memberId;
-    private Role oldRole;
-    private Role newRole;
+    private String oldRole;  
+    private String newRole;  
     private int rootAdminCount;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgReqDTO.java
@@ -30,14 +30,14 @@ public class OrgReqDTO {
 
     private String representativeName;
 
-   @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phone;
 
     private String businessNumber;
 
     @Pattern(
-            regexp = "^(https?://.*|data:image/(png|jpg|jpeg|gif|svg\\+xml);base64,.*)$",
-            message = "올바른 URL 또는 Base64 이미지 데이터여야 합니다"
+            regexp = "^(https?://.*|data:image/(png|jpg|jpeg|gif|svg\\+xml);base64,.*|/images/.*)$",
+            message = "올바른 URL, Base64 이미지 데이터, 또는 기존 이미지 경로여야 합니다"
     )
     private String logoImgUrl;
 

--- a/backend/src/main/java/com/ourhour/domain/org/dto/OrgResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/org/dto/OrgResDTO.java
@@ -1,6 +1,5 @@
 package com.ourhour.domain.org.dto;
 
-import com.ourhour.domain.org.enums.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +21,6 @@ public class OrgResDTO {
     private String businessNumber;
     private String logoImgUrl;
     private String memberName;
-    private Role myRole;
+    private String myRole;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/enums/Role.java
+++ b/backend/src/main/java/com/ourhour/domain/org/enums/Role.java
@@ -3,7 +3,8 @@ package com.ourhour.domain.org.enums;
 public enum Role {
     ROOT_ADMIN("루트관리자", 3),
     ADMIN("관리자", 2),
-    MEMBER("일반회원", 1);
+    MEMBER("일반회원", 1),
+    GUEST("게스트", 0);
 
     private final String description;
     private final int level;

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -23,14 +23,14 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgEntity.businessNumber", target = "businessNumber")
     @Mapping(source = "orgEntity.logoImgUrl", target = "logoImgUrl")
     @Mapping(source = "memberEntity.name", target = "memberName")
-    @Mapping(source = "orgParticipantMemberEntity.role", target = "myRole")
+    @Mapping(target = "myRole", expression = "java(orgParticipantMemberEntity.getRole().getDescription())")
     OrgResDTO toOrgResDTO(OrgEntity orgEntity, MemberEntity memberEntity, OrgParticipantMemberEntity orgParticipantMemberEntity);
 
     // Entity -> DTO 변환 (구성원 권한 변경)
     @Mapping(source = "orgParticipantMemberEntity.orgEntity.orgId", target = "orgId")
     @Mapping(source = "orgParticipantMemberEntity.memberEntity.memberId", target = "memberId")
-    @Mapping(source = "oldRole", target = "oldRole")
-    @Mapping(source = "orgParticipantMemberEntity.role", target = "newRole")
+    @Mapping(target = "oldRole", expression = "java(oldRole.getDescription())")
+    @Mapping(target = "newRole", expression = "java(orgParticipantMemberEntity.getRole().getDescription())")
     @Mapping(source = "rootAdminCount", target = "rootAdminCount")
     OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole, int rootAdminCount);
 

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -1,6 +1,7 @@
 package com.ourhour.domain.org.mapper;
 
 import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
 import com.ourhour.domain.org.dto.OrgResDTO;
 import com.ourhour.domain.org.entity.OrgEntity;
@@ -32,4 +33,15 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgParticipantMemberEntity.role", target = "newRole")
     @Mapping(source = "rootAdminCount", target = "rootAdminCount")
     OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole, int rootAdminCount);
+
+    // Entity -> DTO 변환 (구성원 상세 조회)
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.memberId", target = "memberId")
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.name", target = "name")
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.email", target = "email")
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.phone", target = "phone")
+    @Mapping(source = "orgParticipantMemberEntity.positionEntity.name", target = "positionName")
+    @Mapping(source = "orgParticipantMemberEntity.departmentEntity.name", target = "deptName")
+    @Mapping(source = "orgParticipantMemberEntity.memberEntity.profileImgUrl", target = "profileImgUrl")
+    @Mapping(source = "orgParticipantMemberEntity.role", target = "role")
+    MemberInfoResDTO toMemberInfoResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -22,22 +22,18 @@ import java.util.Optional;
 public interface OrgParticipantMemberRepository
         extends JpaRepository<OrgParticipantMemberEntity, OrgParticipantMemberId> {
 
-    @Query("SELECT new com.ourhour.domain.member.dto.MemberInfoResDTO(" +
-            "m.memberId, m.name, m.email, m.phone, " +
-            "COALESCE(p.name, ''), COALESCE(d.name, ''), m.profileImgUrl) " +
+    @Query("SELECT opm " +
             "FROM OrgParticipantMemberEntity opm " +
             "JOIN opm.memberEntity m " +
             "LEFT JOIN opm.positionEntity p " +
             "LEFT JOIN opm.departmentEntity d " +
             "WHERE opm.orgEntity.orgId = :orgId " +
             "ORDER BY m.memberId ASC")
-    Page<MemberInfoResDTO> findByOrgId(@Param("orgId") Long orgId, Pageable pageable);
+    Page<OrgParticipantMemberEntity> findByOrgId(@Param("orgId") Long orgId, Pageable pageable);
 
     boolean existsByOrgEntity_OrgIdAndMemberEntity_MemberId(Long orgId, Long memberId);
 
-    @Query("SELECT new com.ourhour.domain.member.dto.MemberInfoResDTO(" +
-            "m.memberId, m.name, m.email, m.phone, " +
-            "COALESCE(p.name, ''), COALESCE(d.name, ''), m.profileImgUrl) " +
+    @Query("SELECT opm " +
             "FROM OrgParticipantMemberEntity opm " +
             "JOIN opm.memberEntity m " +
             "LEFT JOIN opm.positionEntity p " +
@@ -80,14 +76,12 @@ public interface OrgParticipantMemberRepository
     // 조직 내 활성 루트 관리자 수 조회
     int countByOrgEntity_OrgIdAndRoleAndStatus(Long orgId, Role role, Status status);
 
-    @Query("SELECT new com.ourhour.domain.member.dto.MemberInfoResDTO(" +
-            "m.memberId, m.name, m.email, m.phone, " +
-            "COALESCE(p.name, ''), COALESCE(d.name, ''), m.profileImgUrl) " +
+    @Query("SELECT opm " +
             "FROM OrgParticipantMemberEntity opm " +
             "JOIN opm.memberEntity m " +
             "LEFT JOIN opm.positionEntity p " +
             "LEFT JOIN opm.departmentEntity d " +
             "WHERE opm.orgEntity.orgId = :orgId " +
             "ORDER BY m.memberId ASC")
-   List<MemberInfoResDTO> findAllByOrgEntity_OrgId(Long orgId);
+   List<OrgParticipantMemberEntity> findAllByOrgEntity_OrgId(Long orgId);
 }

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
@@ -4,6 +4,8 @@ import com.ourhour.domain.member.dto.MemberInfoResDTO;
 import com.ourhour.domain.member.exceptions.MemberException;
 import com.ourhour.domain.org.dto.OrgMemberRoleReqDTO;
 import com.ourhour.domain.org.dto.OrgMemberRoleResDTO;
+import com.ourhour.domain.org.entity.DepartmentEntity;
+import com.ourhour.domain.org.entity.PositionEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
 import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.enums.Status;
@@ -18,8 +20,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +45,20 @@ public class OrgMemberService {
             throw BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId);
         }
 
-        Page<MemberInfoResDTO> memberInfoPage = orgParticipantMemberRepository.findByOrgId(orgId, pageable);
+        Page<OrgParticipantMemberEntity> page = orgParticipantMemberRepository.findByOrgId(orgId, pageable);
+
+        Page<MemberInfoResDTO> memberInfoPage = page.map(entity -> {
+            MemberInfoResDTO dto = new MemberInfoResDTO();
+            dto.setMemberId(entity.getMemberEntity().getMemberId());
+            dto.setName(entity.getMemberEntity().getName());
+            dto.setEmail(entity.getMemberEntity().getEmail());
+            dto.setPhone(entity.getMemberEntity().getPhone());
+            dto.setPositionName(Optional.ofNullable(entity.getPositionEntity()).map(PositionEntity::getName).orElse(null));
+            dto.setDeptName(Optional.ofNullable(entity.getDepartmentEntity()).map(DepartmentEntity::getName).orElse(null));
+            dto.setProfileImgUrl(entity.getMemberEntity().getProfileImgUrl());
+            dto.setRole(entity.getRole().getDescription());
+            return dto;
+        });
 
         return PageResponse.of(memberInfoPage);
     }
@@ -50,7 +66,9 @@ public class OrgMemberService {
     // 회사 구성원 상세 조회
     public MemberInfoResDTO getOrgMember(Long orgId, Long memberId) {
 
-        MemberInfoResDTO memberInfoResDTO = orgParticipantMemberRepository.findByOrgIdAndMemberId(orgId, memberId);
+        OrgParticipantMemberEntity orgParticipantMemberEntity = orgParticipantMemberRepository.findByOrgEntity_OrgIdAndMemberEntity_MemberId(orgId, memberId);  
+
+        MemberInfoResDTO memberInfoResDTO = orgParticipantMemberMapper.toMemberInfoResDTO(orgParticipantMemberEntity);
 
         return memberInfoResDTO;
 
@@ -121,7 +139,10 @@ public class OrgMemberService {
             throw BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId);
         }
 
-        List<MemberInfoResDTO> memberInfoResDTOList = orgParticipantMemberRepository.findAllByOrgEntity_OrgId(orgId);
+        List<OrgParticipantMemberEntity> orgParticipantMemberEntityList = orgParticipantMemberRepository.findAllByOrgEntity_OrgId(orgId);
+        List<MemberInfoResDTO> memberInfoResDTOList = orgParticipantMemberEntityList.stream()
+                .map(orgParticipantMemberMapper::toMemberInfoResDTO)
+                .collect(Collectors.toList());
 
         return memberInfoResDTOList;
     }

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
@@ -126,6 +126,19 @@ public class OrgService {
         OrgEntity orgEntity = orgRepository.findById(orgId)
                 .orElseThrow(() -> BusinessException.badRequest("존재하지 않는 회사 ID 입니다: " + orgId));
 
+        // 이미지 처리
+        String logoUrl = orgDetailReqDTO.getLogoImgUrl();
+
+        // Base64 데이터인 경우 파일로 저장하고 URL로 변환
+        if (logoUrl != null && logoUrl.startsWith("data:image/")) {
+            logoUrl = imageService.saveBase64Image(logoUrl);
+        }
+
+        // 변환된 이미지 URL로 OrgReqDTO 업데이트
+        if (logoUrl != null) {
+            orgDetailReqDTO.setLogoImgUrl(logoUrl);
+        }
+
         orgEntity.updateInfo(orgDetailReqDTO);
 
         OrgEntity updatedOrgEntity = orgRepository.save(orgEntity);

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgService.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.org.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import com.ourhour.domain.auth.exception.AuthException;
@@ -91,10 +92,14 @@ public class OrgService {
         memberRepository.save(memberEntity);
 
         // 해당 회사의 루트 관리자 권한 부여
+        OrgParticipantMemberId orgParticipantMemberId = new OrgParticipantMemberId(orgEntity.getOrgId(), memberEntity.getMemberId());
         OrgParticipantMemberEntity orgParticipantMemberEntity = OrgParticipantMemberEntity.builder()
+                .orgParticipantMemberId(orgParticipantMemberId)
                 .orgEntity(orgEntity)
                 .memberEntity(memberEntity)
                 .role(Role.ROOT_ADMIN)
+                .status(Status.ACTIVE)
+                .joinedAt(LocalDate.now())
                 .build();
         orgParticipantMemberRepository.save(orgParticipantMemberEntity);
 

--- a/frontend/src/api/org/deleteMember.ts
+++ b/frontend/src/api/org/deleteMember.ts
@@ -1,0 +1,25 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface DeleteMemberRequest {
+  orgId: number;
+  memberId: number;
+}
+
+const deleteMember = async (request: DeleteMemberRequest): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.delete(
+      `/api/organizations/${request.orgId}/members/${request.memberId}`,
+    );
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default deleteMember;

--- a/frontend/src/api/org/deleteOrg.ts
+++ b/frontend/src/api/org/deleteOrg.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface DeleteOrgRequest {
+  orgId: number;
+}
+
+const deleteOrg = async (request: DeleteOrgRequest): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.delete(`/api/organizations/${request.orgId}`);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default deleteOrg;

--- a/frontend/src/api/org/getOrgInfo.ts
+++ b/frontend/src/api/org/getOrgInfo.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+interface GetOrgInfoRequest {
+  orgId: number;
+}
+
+export interface OrgBaseInfo {
+  orgId: number;
+  name: string;
+  address: string;
+  email: string;
+  representativeName: string;
+  phone: string;
+  businessNumber: string;
+  logoImgUrl: string;
+}
+
+const getOrgInfo = async (request: GetOrgInfoRequest): Promise<ApiResponse<OrgBaseInfo>> => {
+  try {
+    const response = await axiosInstance.get(`/api/organizations/${request.orgId}`);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default getOrgInfo;

--- a/frontend/src/api/org/getOrgMemberList.ts
+++ b/frontend/src/api/org/getOrgMemberList.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios';
 
 import { ApiResponse, PageResponse } from '@/types/apiTypes';
+import { Member } from '@/types/memberTypes';
 
 import { axiosInstance } from '@/api/axiosConfig';
 import { logError } from '@/utils/auth/errorUtils';
@@ -9,16 +10,6 @@ interface GetOrgMemberListRequest {
   orgId: number;
   currentPage?: number;
   size?: number;
-}
-
-export interface Member {
-  memberId: number;
-  name: string;
-  phone: string;
-  email: string;
-  departmentName: string;
-  positionName: string;
-  profileImgUrl: string;
 }
 
 const getOrgMemberList = async (

--- a/frontend/src/api/org/patchMemberRole.ts
+++ b/frontend/src/api/org/patchMemberRole.ts
@@ -1,0 +1,39 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+import { MemberRoleEng, MemberRoleKo } from '@/types/memberTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface PatchMemberRoleRequest {
+  orgId: number;
+  memberId: number;
+  newRole: MemberRoleEng;
+}
+
+interface PatchMemberRoleResponse {
+  orgId: number;
+  memberId: number;
+  oldRole: MemberRoleKo;
+  newRole: MemberRoleKo;
+  rootAdminCount: number;
+}
+
+const patchMemberRole = async (
+  request: PatchMemberRoleRequest,
+): Promise<ApiResponse<PatchMemberRoleResponse>> => {
+  try {
+    const { orgId, memberId, ...requestBody } = request;
+    const response = await axiosInstance.patch(
+      `/api/organizations/${orgId}/members/${memberId}/role`,
+      requestBody,
+    );
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default patchMemberRole;

--- a/frontend/src/api/org/postCreateOrg.ts
+++ b/frontend/src/api/org/postCreateOrg.ts
@@ -3,6 +3,7 @@ import { AxiosError } from 'axios';
 import { ApiResponse } from '@/types/apiTypes';
 
 import { axiosInstance } from '@/api/axiosConfig';
+import { OrgBaseInfo } from '@/api/org/getOrgInfo';
 import { logError } from '@/utils/auth/errorUtils';
 
 export interface PostCreateOrgRequest {
@@ -16,15 +17,7 @@ export interface PostCreateOrgRequest {
   logoImgUrl: string | null;
 }
 
-export interface PostCreateOrgResponse {
-  orgId: number;
-  name: string;
-  address: string;
-  email: string;
-  representativeName: string;
-  phone: string;
-  businessNumber: string;
-  logoImgUrl: string;
+export interface PostCreateOrgResponse extends OrgBaseInfo {
   memberName: string;
   myRole: string;
 }

--- a/frontend/src/api/org/putUpdateOrg.ts
+++ b/frontend/src/api/org/putUpdateOrg.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { OrgBaseInfo } from '@/api/org/getOrgInfo';
+import { logError } from '@/utils/auth/errorUtils';
+
+const putUpdateOrg = async (request: OrgBaseInfo): Promise<ApiResponse<OrgBaseInfo>> => {
+  try {
+    const { orgId, ...requestBody } = request;
+    const response = await axiosInstance.put(`/api/organizations/${orgId}`, requestBody);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default putUpdateOrg;

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -102,6 +102,13 @@ const LoginForm = ({
     onSubmit(email, password);
   };
 
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
+    }
+  };
+
   return (
     <form className="space-y-6" onSubmit={handleSubmit}>
       <div className="space-y-2">
@@ -115,6 +122,7 @@ const LoginForm = ({
           placeholder="이메일을 입력하세요"
           value={email}
           onChange={handleEmailChange}
+          onKeyDown={handleKeyPress}
           disabled={isLoading}
           className={emailError ? 'border-red-500' : ''}
         />
@@ -132,6 +140,7 @@ const LoginForm = ({
           placeholder="비밀번호를 입력하세요"
           value={password}
           onChange={handlePasswordChange}
+          onKeyDown={handleKeyPress}
           disabled={isLoading}
           className={passwordError ? 'border-red-500' : ''}
         />

--- a/frontend/src/components/auth/SignupForm.tsx
+++ b/frontend/src/components/auth/SignupForm.tsx
@@ -49,7 +49,13 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
     setEmailError(emailValidation.error);
     setPasswordError(passwordValidation.error);
 
-    if (!emailValidation.isValid || !passwordValidation.isValid) {
+    // 비밀번호 확인 검증 추가
+    if (passwordConfirm !== password) {
+      setPasswordConfirmError('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    if (!emailValidation.isValid || !passwordValidation.isValid || passwordConfirm !== password) {
       return;
     }
 
@@ -69,6 +75,15 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
   const handlePasswordConfirmBlur = () => {
     if (passwordConfirm !== password) {
       setPasswordConfirmError('비밀번호가 일치하지 않습니다.');
+    } else {
+      setPasswordConfirmError('');
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit(e as unknown as React.FormEvent<HTMLFormElement>);
     }
   };
 
@@ -85,6 +100,7 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
           placeholder="이메일을 입력하세요"
           value={email}
           onChange={handleEmailChange}
+          onKeyPress={handleKeyPress}
           disabled={isLoading}
           className={emailError ? 'border-red-500' : ''}
         />
@@ -102,6 +118,7 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
           placeholder="비밀번호를 입력하세요"
           value={password}
           onChange={handlePasswordChange}
+          onKeyDown={handleKeyPress}
           disabled={isLoading}
           className={passwordError ? 'border-red-500' : ''}
         />
@@ -120,10 +137,11 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
           value={passwordConfirm}
           onChange={handlePasswordConfirmChange}
           onBlur={handlePasswordConfirmBlur}
+          onKeyDown={handleKeyPress}
           disabled={isLoading}
           className={passwordConfirmError ? 'border-red-500' : ''}
         />
-        {passwordConfirmError && <p className="text-sm text-red-600">{passwordConfirmError}</p>}
+        {passwordConfirmError && <div className="text-sm text-red-600">{passwordConfirmError}</div>}
       </div>
 
       <ButtonComponent

--- a/frontend/src/components/common/left-sidebar/AppSidebarComponent.tsx
+++ b/frontend/src/components/common/left-sidebar/AppSidebarComponent.tsx
@@ -156,7 +156,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" className="mt-16" {...props}>
       <SidebarHeader>
-        <TeamSwitcher teams={data.teams} />
+        <TeamSwitcher />
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.navMain} />

--- a/frontend/src/components/org/LogoUpload.tsx
+++ b/frontend/src/components/org/LogoUpload.tsx
@@ -1,12 +1,20 @@
 import { Upload } from 'lucide-react';
 
+import { getImageUrl } from '@/utils/file/imageUtils';
+
 interface LogoUploadProps {
+  logoImgUrl: string;
   logoPreview: string;
   onLogoUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onFileSelect?: (file: File) => void;
 }
 
-export function LogoUpload({ logoPreview, onLogoUpload, onFileSelect }: LogoUploadProps) {
+export function LogoUpload({
+  logoImgUrl,
+  logoPreview,
+  onLogoUpload,
+  onFileSelect,
+}: LogoUploadProps) {
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
@@ -19,9 +27,9 @@ export function LogoUpload({ logoPreview, onLogoUpload, onFileSelect }: LogoUplo
     <div className="flex justify-center">
       <div className="relative">
         <div className="w-24 h-24 bg-white rounded-full flex items-center justify-center overflow-hidden border border-gray-200">
-          {logoPreview ? (
+          {logoPreview || logoImgUrl ? (
             <img
-              src={logoPreview}
+              src={logoPreview || getImageUrl(logoImgUrl)}
               alt="회사 로고"
               className="w-full h-full object-contain bg-white rounded-full"
               style={{

--- a/frontend/src/components/org/OrgBasicInfo.tsx
+++ b/frontend/src/components/org/OrgBasicInfo.tsx
@@ -15,23 +15,26 @@ interface OrgBasicInfoProps {
     phone: string;
   };
   onInputChange: (field: string, value: string) => void;
+  isEditing: boolean;
 }
 
-export function OrgBasicInfo({ formData, onInputChange }: OrgBasicInfoProps) {
+export function OrgBasicInfo({ formData, onInputChange, isEditing }: OrgBasicInfoProps) {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Label htmlFor="memberName" className="text-sm font-medium">
-          활동 이름 <span className="text-red-500">*</span>
-        </Label>
-        <Input
-          id="memberName"
-          placeholder="활동 이름을 입력하세요"
-          value={formData.memberName}
-          onChange={(e) => onInputChange('memberName', e.target.value)}
-          required
-        />
-      </div>
+      {!isEditing && (
+        <div className="space-y-2">
+          <Label htmlFor="memberName" className="text-sm font-medium">
+            활동 이름 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="memberName"
+            placeholder="활동 이름을 입력하세요"
+            value={formData.memberName}
+            onChange={(e) => onInputChange('memberName', e.target.value)}
+            required
+          />
+        </div>
+      )}
 
       <div className="space-y-2">
         <div className="flex items-center space-x-2">

--- a/frontend/src/components/project/info/ProjectInfoPage.tsx
+++ b/frontend/src/components/project/info/ProjectInfoPage.tsx
@@ -151,6 +151,7 @@ export const ProjectInfoPage = ({ projectId, orgId }: ProjectInfoPageProps) => {
           </div>
 
           <ProjectMembersTable
+            type="project"
             projectMembers={projectMembers}
             selectedMemberIds={selectedMemberIds}
             onSelectionChange={handleMemberSelectionChange}
@@ -174,24 +175,27 @@ export const ProjectInfoPage = ({ projectId, orgId }: ProjectInfoPageProps) => {
           setSelectedParticipantIds={setSelectedParticipantIds}
         />
       )}
-      <ModalComponent
-        isOpen={isDeleteModalOpen}
-        onClose={handleDeleteModalClose}
-        title="비밀번호 확인"
-        children={
-          <Input
-            type="password"
-            placeholder="비밀번호를 입력해주세요."
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        }
-        footer={
-          <ButtonComponent variant="danger" onClick={handleDeleteProject}>
-            프로젝트 삭제
-          </ButtonComponent>
-        }
-      />
+
+      {isDeleteModalOpen && (
+        <ModalComponent
+          isOpen={isDeleteModalOpen}
+          onClose={handleDeleteModalClose}
+          title="비밀번호 확인"
+          children={
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력해주세요."
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          }
+          footer={
+            <ButtonComponent variant="danger" onClick={handleDeleteProject}>
+              프로젝트 삭제
+            </ButtonComponent>
+          }
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/components/project/info/ProjectMembersTable.tsx
+++ b/frontend/src/components/project/info/ProjectMembersTable.tsx
@@ -1,10 +1,18 @@
 import { Trash2 } from 'lucide-react';
 
-import { Member } from '@/api/org/getOrgMemberList';
+import { Member, MemberRole } from '@/types/memberTypes';
+
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { PaginationComponent } from '@/components/common/PaginationComponent';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   Table,
   TableBody,
@@ -13,22 +21,27 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { MEMBER_ROLE_STYLES } from '@/constants/badges';
 
 interface ProjectMembersTableProps {
+  type: 'project' | 'org';
   projectMembers?: Member[];
   selectedMemberIds: number[];
   onSelectionChange: (memberIds: number[]) => void;
   onDeleteSelected: () => void;
+  onRoleChange?: (memberId: number, newRole: MemberRole) => void;
   participantTotalPages: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
 }
 
 export const ProjectMembersTable = ({
+  type,
   projectMembers,
   selectedMemberIds,
   onSelectionChange,
   onDeleteSelected,
+  onRoleChange,
   participantTotalPages,
   currentPage,
   setCurrentPage,
@@ -49,23 +62,23 @@ export const ProjectMembersTable = ({
     }
   };
 
+  const handleRoleChange = (memberId: number, newRole: string) => {
+    if (onRoleChange) {
+      onRoleChange(memberId, newRole as MemberRole);
+    }
+  };
+
   const isAllSelected =
     projectMembers &&
     projectMembers.length > 0 &&
     projectMembers.every((member) => selectedMemberIds.includes(member.memberId));
 
-  // const getRoleColor = (role: string) => {
-  //   switch (role) {
-  //     case '루트관리자':
-  //       return 'bg-purple-100 text-purple-800';
-  //     case '관리자':
-  //       return 'bg-red-100 text-red-800';
-  //     case '일반':
-  //       return 'bg-blue-100 text-blue-800';
-  //     default:
-  //       return 'bg-gray-100 text-gray-800';
-  //   }
-  // };
+  const roleOptions = [
+    { value: MemberRole.ROOT_ADMIN, label: '루트관리자' },
+    { value: MemberRole.ADMIN, label: '관리자' },
+    { value: MemberRole.MEMBER, label: '일반회원' },
+    { value: MemberRole.GUEST, label: '게스트' },
+  ];
 
   return (
     <div className="space-y-4">
@@ -97,6 +110,7 @@ export const ProjectMembersTable = ({
               <TableHead className="w-24 text-center">직책</TableHead>
               <TableHead className="w-32 text-center">연락처</TableHead>
               <TableHead className="w-48 text-center">이메일</TableHead>
+              {type === 'org' && <TableHead className="w-48 text-center">권한</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -119,10 +133,39 @@ export const ProjectMembersTable = ({
                     <span className="font-medium truncate">{member.name}</span>
                   </div>
                 </TableCell>
-                <TableCell className="w-24 text-center truncate">{member.departmentName}</TableCell>
+                <TableCell className="w-24 text-center truncate">{member.deptName}</TableCell>
                 <TableCell className="w-24 text-center truncate">{member.positionName}</TableCell>
                 <TableCell className="w-32 text-center truncate">{member.phone}</TableCell>
                 <TableCell className="w-48 text-center truncate">{member.email}</TableCell>
+                {type === 'org' && (
+                  <TableCell className="w-48 text-center">
+                    <Select
+                      value={member.role}
+                      onValueChange={(value) => handleRoleChange(member.memberId, value)}
+                    >
+                      <SelectTrigger className="w-32 mx-auto">
+                        <SelectValue>
+                          <div
+                            className={`rounded-full px-2 py-1 text-xs ${MEMBER_ROLE_STYLES[member.role]}`}
+                          >
+                            {member.role}
+                          </div>
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {roleOptions.map((role) => (
+                          <SelectItem key={role.value} value={role.value}>
+                            <div
+                              className={`rounded-full px-2 py-1 text-xs ${MEMBER_ROLE_STYLES[role.label as keyof typeof MEMBER_ROLE_STYLES]}`}
+                            >
+                              {role.label}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                )}
               </TableRow>
             ))}
           </TableBody>

--- a/frontend/src/components/project/info/ProjectMembersTable.tsx
+++ b/frontend/src/components/project/info/ProjectMembersTable.tsx
@@ -1,6 +1,6 @@
 import { Trash2 } from 'lucide-react';
 
-import { Member, MemberRole } from '@/types/memberTypes';
+import { Member, MemberRoleKo } from '@/types/memberTypes';
 
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { PaginationComponent } from '@/components/common/PaginationComponent';
@@ -29,7 +29,7 @@ interface ProjectMembersTableProps {
   selectedMemberIds: number[];
   onSelectionChange: (memberIds: number[]) => void;
   onDeleteSelected: () => void;
-  onRoleChange?: (memberId: number, newRole: MemberRole) => void;
+  onRoleChange?: (memberId: number, newRole: MemberRoleKo) => void;
   participantTotalPages: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
@@ -64,7 +64,7 @@ export const ProjectMembersTable = ({
 
   const handleRoleChange = (memberId: number, newRole: string) => {
     if (onRoleChange) {
-      onRoleChange(memberId, newRole as MemberRole);
+      onRoleChange(memberId, newRole as MemberRoleKo);
     }
   };
 
@@ -74,10 +74,10 @@ export const ProjectMembersTable = ({
     projectMembers.every((member) => selectedMemberIds.includes(member.memberId));
 
   const roleOptions = [
-    { value: MemberRole.ROOT_ADMIN, label: '루트관리자' },
-    { value: MemberRole.ADMIN, label: '관리자' },
-    { value: MemberRole.MEMBER, label: '일반회원' },
-    { value: MemberRole.GUEST, label: '게스트' },
+    { value: '루트관리자', label: '루트관리자' },
+    { value: '관리자', label: '관리자' },
+    { value: '일반회원', label: '일반회원' },
+    { value: '게스트', label: '게스트' },
   ];
 
   return (

--- a/frontend/src/constants/badges.ts
+++ b/frontend/src/constants/badges.ts
@@ -13,3 +13,10 @@ export const ISSUE_STATUS_STYLES = {
   진행중: 'bg-pink-100 text-pink-800',
   완료됨: 'bg-green-100 text-green-800',
 } as const;
+
+export const MEMBER_ROLE_STYLES = {
+  루트관리자: 'bg-purple-100 text-purple-800',
+  관리자: 'bg-red-100 text-red-800',
+  일반회원: 'bg-blue-100 text-blue-800',
+  게스트: 'bg-gray-100 text-gray-800',
+} as const;

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -10,4 +10,5 @@ export const PROJECT_QUERY_KEYS = {
 export const ORG_QUERY_KEYS = {
   MEMBER_LIST: 'orgMemberList',
   MY_ORG_LIST: 'myOrgList',
+  ORG_INFO: 'orgInfo',
 } as const;

--- a/frontend/src/hooks/queries/org/useMemberDeleteMutation.ts
+++ b/frontend/src/hooks/queries/org/useMemberDeleteMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import deleteMember, { DeleteMemberRequest } from '@/api/org/deleteMember';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+export const useMemberDeleteMutation = () =>
+  useMutation({
+    mutationFn: (request: DeleteMemberRequest) => deleteMember(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ORG_QUERY_KEYS.MEMBER_LIST],
+        exact: false,
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/org/useOrgDeleteMutation.ts
+++ b/frontend/src/hooks/queries/org/useOrgDeleteMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import deleteOrg, { DeleteOrgRequest } from '@/api/org/deleteOrg';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+export const useOrgDeleteMutation = () =>
+  useMutation({
+    mutationFn: (request: DeleteOrgRequest) => deleteOrg(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ORG_QUERY_KEYS.MY_ORG_LIST],
+        exact: false,
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/org/useOrgInfoQuery.ts
+++ b/frontend/src/hooks/queries/org/useOrgInfoQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import getOrgInfo from '@/api/org/getOrgInfo';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+
+interface UseOrgInfoParams {
+  orgId: number;
+  enabled?: boolean;
+}
+
+const useOrgInfoQuery = ({ orgId, enabled = true }: UseOrgInfoParams) =>
+  useQuery({
+    queryKey: [ORG_QUERY_KEYS.ORG_INFO, orgId],
+    queryFn: () => getOrgInfo({ orgId }),
+    enabled: enabled && !!orgId,
+  });
+
+export default useOrgInfoQuery;

--- a/frontend/src/hooks/queries/org/useOrgUpdateMutation.ts
+++ b/frontend/src/hooks/queries/org/useOrgUpdateMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import { OrgBaseInfo } from '@/api/org/getOrgInfo';
+import putUpdateOrg from '@/api/org/putUpdateOrg';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+interface UseOrgUpdateMutationParams {
+  orgId: number;
+}
+
+export const useOrgUpdateMutation = ({ orgId }: UseOrgUpdateMutationParams) =>
+  useMutation({
+    mutationFn: (request: OrgBaseInfo) => putUpdateOrg({ ...request, orgId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ORG_QUERY_KEYS.ORG_INFO, orgId],
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/org/usePatchMemberRole.ts
+++ b/frontend/src/hooks/queries/org/usePatchMemberRole.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import patchMemberRole, { PatchMemberRoleRequest } from '@/api/org/patchMemberRole';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+interface UsePatchMemberRoleMutationParams {
+  orgId: number;
+}
+
+export const usePatchMemberRoleMutation = ({ orgId }: UsePatchMemberRoleMutationParams) =>
+  useMutation({
+    mutationFn: (request: PatchMemberRoleRequest) => patchMemberRole(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ORG_QUERY_KEYS.MEMBER_LIST, orgId],
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/routes/org/$orgId/info/index.tsx
+++ b/frontend/src/routes/org/$orgId/info/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { createFileRoute, useRouter } from '@tanstack/react-router';
 
-import { MemberRole } from '@/types/memberTypes';
+import { MEMBER_ROLE_KO_TO_ENG, MemberRoleKo } from '@/types/memberTypes';
 
 import { OrgBaseInfo } from '@/api/org/getOrgInfo';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
@@ -15,6 +15,7 @@ import { useOrgDeleteMutation } from '@/hooks/queries/org/useOrgDeleteMutation';
 import useOrgInfoQuery from '@/hooks/queries/org/useOrgInfoQuery';
 import useOrgMemberListQuery from '@/hooks/queries/org/useOrgMemberListQuery';
 import { useOrgUpdateMutation } from '@/hooks/queries/org/useOrgUpdateMutation';
+import { usePatchMemberRoleMutation } from '@/hooks/queries/org/usePatchMemberRole';
 import usePasswordVerificationMutation from '@/hooks/queries/user/usePasswordVerificationMutation';
 import { getImageUrl } from '@/utils/file/imageUtils';
 import { showErrorToast, showSuccessToast, TOAST_MESSAGES } from '@/utils/toast';
@@ -44,7 +45,7 @@ function OrgInfoPage() {
   // 권한 변경을 위한 임시 상태
   const [pendingRoleChange, setPendingRoleChange] = useState<{
     memberId: number;
-    newRole: MemberRole;
+    newRole: MemberRoleKo;
   } | null>(null);
 
   const { data: orgInfoData } = useOrgInfoQuery({ orgId: Number(orgId) });
@@ -67,6 +68,10 @@ function OrgInfoPage() {
   const { mutate: deleteOrg } = useOrgDeleteMutation();
 
   const { mutate: deleteMember } = useMemberDeleteMutation();
+
+  const { mutate: patchMemberRole } = usePatchMemberRoleMutation({
+    orgId: Number(orgId),
+  });
 
   const handleEditProject = () => {
     setIsEditModalOpen(true);
@@ -142,7 +147,7 @@ function OrgInfoPage() {
     setImageErrors((prev) => new Set(prev).add(orgId));
   };
 
-  const handleRoleChange = (memberId: number, newRole: MemberRole) => {
+  const handleRoleChange = (memberId: number, newRole: MemberRoleKo) => {
     // 권한 변경 시 비밀번호 확인 모달 열기
     setPendingRoleChange({ memberId, newRole });
     setIsRoleChangeModalOpen(true);
@@ -156,10 +161,11 @@ function OrgInfoPage() {
     try {
       passwordVerification({ password });
 
-      console.log('memberId', pendingRoleChange.memberId);
-      console.log('newRole', pendingRoleChange.newRole);
-      // 권한 변경 API 호출
-      // updateMemberRole({ memberId: pendingRoleChange.memberId, newRole: pendingRoleChange.newRole });
+      patchMemberRole({
+        orgId: Number(orgId),
+        memberId: pendingRoleChange.memberId,
+        newRole: MEMBER_ROLE_KO_TO_ENG[pendingRoleChange.newRole],
+      });
 
       setIsRoleChangeModalOpen(false);
       setPassword('');

--- a/frontend/src/routes/org/$orgId/info/index.tsx
+++ b/frontend/src/routes/org/$orgId/info/index.tsx
@@ -1,0 +1,297 @@
+import { useState } from 'react';
+
+import { createFileRoute, useRouter } from '@tanstack/react-router';
+
+import { MemberRole } from '@/types/memberTypes';
+
+import { OrgBaseInfo } from '@/api/org/getOrgInfo';
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { ModalComponent } from '@/components/common/ModalComponent';
+import { OrgModal } from '@/components/org/OrgModal';
+import { ProjectMembersTable } from '@/components/project/info/ProjectMembersTable';
+import { Input } from '@/components/ui/input';
+import { useOrgDeleteMutation } from '@/hooks/queries/org/useOrgDeleteMutation';
+import useOrgInfoQuery from '@/hooks/queries/org/useOrgInfoQuery';
+import useOrgMemberListQuery from '@/hooks/queries/org/useOrgMemberListQuery';
+import { useOrgUpdateMutation } from '@/hooks/queries/org/useOrgUpdateMutation';
+import usePasswordVerificationMutation from '@/hooks/queries/user/usePasswordVerificationMutation';
+import { getImageUrl } from '@/utils/file/imageUtils';
+import { showErrorToast, showSuccessToast, TOAST_MESSAGES } from '@/utils/toast';
+
+export const Route = createFileRoute('/org/$orgId/info/')({
+  component: OrgInfoPage,
+});
+
+function OrgInfoPage() {
+  const { orgId } = Route.useParams();
+
+  const router = useRouter();
+
+  const [currentPage, setCurrentPage] = useState(1);
+  // 회사 구성원 삭제
+  const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
+
+  // 비밀번호 확인
+  const [password, setPassword] = useState('');
+
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isRoleChangeModalOpen, setIsRoleChangeModalOpen] = useState(false);
+
+  const [imageErrors, setImageErrors] = useState<Set<number>>(new Set());
+
+  // 권한 변경을 위한 임시 상태
+  const [pendingRoleChange, setPendingRoleChange] = useState<{
+    memberId: number;
+    newRole: MemberRole;
+  } | null>(null);
+
+  const { data: orgInfoData } = useOrgInfoQuery({ orgId: Number(orgId) });
+
+  const orgInfo = orgInfoData as OrgBaseInfo | undefined;
+
+  const { data: orgMembersData } = useOrgMemberListQuery({
+    orgId: Number(orgId),
+    currentPage,
+  });
+
+  const orgMembers = Array.isArray(orgMembersData?.data) ? orgMembersData.data : [];
+
+  const { mutate: passwordVerification } = usePasswordVerificationMutation();
+
+  const { mutate: updateOrg } = useOrgUpdateMutation({
+    orgId: Number(orgId),
+  });
+
+  const { mutate: deleteOrg } = useOrgDeleteMutation();
+
+  const handleEditProject = () => {
+    setIsEditModalOpen(true);
+  };
+
+  const handleEditModalClose = () => {
+    setIsEditModalOpen(false);
+  };
+
+  // 수정 버튼 클릭시
+  const handleProjectSubmit = (data: Partial<OrgBaseInfo>) => {
+    try {
+      updateOrg({
+        orgId: Number(orgId),
+        name: data.name || '',
+        address: data.address || '',
+        email: data.email || '',
+        representativeName: data.representativeName || '',
+        phone: data.phone || '',
+        businessNumber: data.businessNumber || '',
+        logoImgUrl: data.logoImgUrl || '',
+      });
+      showSuccessToast(TOAST_MESSAGES.CRUD.UPDATE_SUCCESS);
+      handleEditModalClose();
+    } catch (error) {
+      // 에러 토스트
+    }
+  };
+
+  const handleMemberSelectionChange = (memberIds: number[]) => {
+    setSelectedMemberIds(memberIds);
+  };
+
+  const handleDeleteSelectedMembers = () => {
+    console.log('선택된 구성원 삭제:', selectedMemberIds);
+    setSelectedMemberIds([]);
+  };
+
+  const handleDeleteOrg = () => {
+    try {
+      passwordVerification({ password });
+      deleteOrg({ orgId: Number(orgId) });
+      setIsDeleteModalOpen(false);
+      router.navigate({
+        to: '/start',
+        search: { page: 1 },
+      });
+      setSelectedMemberIds([]);
+      setPassword('');
+      showSuccessToast(TOAST_MESSAGES.CRUD.DELETE_SUCCESS);
+    } catch (error) {
+      showErrorToast('비밀번호가 일치하지 않습니다.');
+      setPassword('');
+    }
+  };
+
+  const openDeleteModal = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteModalClose = () => {
+    setIsDeleteModalOpen(false);
+  };
+
+  const handleImageError = (orgId: number) => {
+    setImageErrors((prev) => new Set(prev).add(orgId));
+  };
+
+  const handleRoleChange = (memberId: number, newRole: MemberRole) => {
+    // 권한 변경 시 비밀번호 확인 모달 열기
+    setPendingRoleChange({ memberId, newRole });
+    setIsRoleChangeModalOpen(true);
+  };
+
+  const handleRoleChangeConfirm = () => {
+    if (!pendingRoleChange) {
+      return;
+    }
+
+    try {
+      passwordVerification({ password });
+
+      console.log('memberId', pendingRoleChange.memberId);
+      console.log('newRole', pendingRoleChange.newRole);
+      // 권한 변경 API 호출
+      // updateMemberRole({ memberId: pendingRoleChange.memberId, newRole: pendingRoleChange.newRole });
+
+      setIsRoleChangeModalOpen(false);
+      setPassword('');
+      setPendingRoleChange(null);
+      showSuccessToast('권한이 변경되었습니다.');
+    } catch (error) {
+      showErrorToast('비밀번호가 일치하지 않습니다.');
+      setPassword('');
+    }
+  };
+
+  const handleRoleChangeModalClose = () => {
+    setIsRoleChangeModalOpen(false);
+    setPassword('');
+    setPendingRoleChange(null);
+  };
+
+  return (
+    <>
+      <div className="bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div>
+            <div className="flex justify-between items-start mb-5">
+              <div className="flex items-center gap-4">
+                <div className="flex size-12 items-center justify-center rounded-md border">
+                  {orgInfo?.logoImgUrl && !imageErrors.has(orgInfo?.orgId) ? (
+                    <img
+                      src={getImageUrl(orgInfo.logoImgUrl)}
+                      alt={orgInfo.name}
+                      width={48}
+                      height={48}
+                      className="size-12 object-cover rounded-md"
+                      onError={() => handleImageError(orgInfo?.orgId)}
+                    />
+                  ) : (
+                    <div className="size-12 bg-gray-200 rounded flex items-center justify-center">
+                      <span className="font-bold text-lg text-black">
+                        {orgInfo?.name.charAt(0).toUpperCase()}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <h1 className="text-3xl font-bold text-gray-900">{orgInfo?.name}</h1>
+              </div>
+              <div className="flex items-center gap-4">
+                <ButtonComponent variant="secondary" onClick={handleEditProject}>
+                  회사 정보 수정
+                </ButtonComponent>
+                <ButtonComponent variant="danger" onClick={openDeleteModal}>
+                  회사 삭제
+                </ButtonComponent>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="text-gray-600 font-bold">주소</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.address}</p>
+              <div className="text-gray-600 font-bold">이메일</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.email}</p>
+              <div className="text-gray-600 font-bold">전화번호</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.phone}</p>
+              <div className="text-gray-600 font-bold">사업자번호</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.businessNumber}</p>
+              <div className="text-gray-600 font-bold">대표자</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.representativeName}</p>
+            </div>
+          </div>
+
+          <ProjectMembersTable
+            type="org"
+            projectMembers={orgMembers}
+            selectedMemberIds={selectedMemberIds}
+            onSelectionChange={handleMemberSelectionChange}
+            onDeleteSelected={handleDeleteSelectedMembers}
+            participantTotalPages={orgMembersData?.data.totalPages || 1}
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+            onRoleChange={handleRoleChange}
+          />
+        </div>
+      </div>
+
+      {isEditModalOpen && (
+        <OrgModal
+          isOpen={isEditModalOpen}
+          onClose={handleEditModalClose}
+          initialInfoData={orgInfo}
+          onSubmit={handleProjectSubmit}
+        />
+      )}
+
+      {isDeleteModalOpen && (
+        <ModalComponent
+          isOpen={isDeleteModalOpen}
+          onClose={handleDeleteModalClose}
+          title="비밀번호 확인"
+          children={
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                회사를 삭제하려면 본인의 비밀번호를 입력해주세요.
+              </p>
+              <Input
+                type="password"
+                placeholder="비밀번호를 입력해주세요."
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+          }
+          footer={
+            <ButtonComponent variant="danger" onClick={handleDeleteOrg}>
+              회사 삭제
+            </ButtonComponent>
+          }
+        />
+      )}
+
+      {isRoleChangeModalOpen && (
+        <ModalComponent
+          isOpen={isRoleChangeModalOpen}
+          onClose={handleRoleChangeModalClose}
+          title="권한 변경 확인"
+          children={
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                구성원의 권한을 변경하려면 본인의 비밀번호를 입력해주세요.
+              </p>
+              <Input
+                type="password"
+                placeholder="비밀번호를 입력해주세요."
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+          }
+          footer={
+            <ButtonComponent variant="primary" onClick={handleRoleChangeConfirm}>
+              권한 변경
+            </ButtonComponent>
+          }
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/routes/org/$orgId/info/index.tsx
+++ b/frontend/src/routes/org/$orgId/info/index.tsx
@@ -10,6 +10,7 @@ import { ModalComponent } from '@/components/common/ModalComponent';
 import { OrgModal } from '@/components/org/OrgModal';
 import { ProjectMembersTable } from '@/components/project/info/ProjectMembersTable';
 import { Input } from '@/components/ui/input';
+import { useMemberDeleteMutation } from '@/hooks/queries/org/useMemberDeleteMutation';
 import { useOrgDeleteMutation } from '@/hooks/queries/org/useOrgDeleteMutation';
 import useOrgInfoQuery from '@/hooks/queries/org/useOrgInfoQuery';
 import useOrgMemberListQuery from '@/hooks/queries/org/useOrgMemberListQuery';
@@ -65,6 +66,8 @@ function OrgInfoPage() {
 
   const { mutate: deleteOrg } = useOrgDeleteMutation();
 
+  const { mutate: deleteMember } = useMemberDeleteMutation();
+
   const handleEditProject = () => {
     setIsEditModalOpen(true);
   };
@@ -98,8 +101,15 @@ function OrgInfoPage() {
   };
 
   const handleDeleteSelectedMembers = () => {
-    console.log('선택된 구성원 삭제:', selectedMemberIds);
-    setSelectedMemberIds([]);
+    try {
+      selectedMemberIds.forEach((memberId) => {
+        deleteMember({ orgId: Number(orgId), memberId });
+      });
+      showSuccessToast(TOAST_MESSAGES.CRUD.DELETE_SUCCESS);
+      setSelectedMemberIds([]);
+    } catch (error) {
+      // 에러 토스트
+    }
   };
 
   const handleDeleteOrg = () => {

--- a/frontend/src/routes/signup/index.tsx
+++ b/frontend/src/routes/signup/index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import { ChevronLeft } from 'lucide-react';
 
+import landingImage from '@/assets/images/landing-1.jpg';
 import ErrorMessage from '@/components/auth/ErrorMessage';
 import SignupForm from '@/components/auth/SignupForm';
 import { AUTH_MESSAGES } from '@/constants/messages';
@@ -54,7 +55,7 @@ function SignupPage() {
   return (
     <div className="min-h-screen flex">
       <div className="hidden lg:block lg:w-2/3">
-        <img src="/images/landing-1.jpg" alt="login-background" className="w-full h-full" />
+        <img src={landingImage} alt="signup-background" className="w-full h-full" />
       </div>
 
       <div className="w-full lg:w-1/2 flex items-center justify-center p-8 relative">

--- a/frontend/src/types/memberTypes.ts
+++ b/frontend/src/types/memberTypes.ts
@@ -1,3 +1,10 @@
+export enum MemberRole {
+  ROOT_ADMIN = '루트관리자',
+  ADMIN = '관리자',
+  MEMBER = '일반회원',
+  GUEST = '게스트',
+}
+
 export interface Member {
   memberId: number;
   name: string;
@@ -6,4 +13,5 @@ export interface Member {
   positionName: string;
   deptName: string;
   profileImgUrl: string;
+  role: MemberRole;
 }

--- a/frontend/src/types/memberTypes.ts
+++ b/frontend/src/types/memberTypes.ts
@@ -1,9 +1,20 @@
-export enum MemberRole {
-  ROOT_ADMIN = '루트관리자',
-  ADMIN = '관리자',
-  MEMBER = '일반회원',
-  GUEST = '게스트',
-}
+export type MemberRoleKo = '루트관리자' | '관리자' | '일반회원' | '게스트';
+
+export type MemberRoleEng = 'ROOT_ADMIN' | 'ADMIN' | 'MEMBER' | 'GUEST';
+
+export const MEMBER_ROLE_ENG_TO_KO: Record<MemberRoleEng, MemberRoleKo> = {
+  ROOT_ADMIN: '루트관리자',
+  ADMIN: '관리자',
+  MEMBER: '일반회원',
+  GUEST: '게스트',
+};
+
+export const MEMBER_ROLE_KO_TO_ENG: Record<MemberRoleKo, MemberRoleEng> = {
+  루트관리자: 'ROOT_ADMIN',
+  관리자: 'ADMIN',
+  일반회원: 'MEMBER',
+  게스트: 'GUEST',
+};
 
 export interface Member {
   memberId: number;
@@ -13,5 +24,5 @@ export interface Member {
   positionName: string;
   deptName: string;
   profileImgUrl: string;
-  role: MemberRole;
+  role: MemberRoleKo;
 }


### PR DESCRIPTION
## 📌 제목
feat(fe): 회사 정보 페이지 ui 구현 및 api 연동

----------------------------------------

## 🔗 관련 이슈

## ✅ 작업 내용
- 회사 정보 페이지 ui 구현 
- 백엔드 role 반환값 영어->한글로 변경
- 백엔드 role enum에 guest 추가
- 회사 정보 조회 api 연동
- 좌측 사이드바 회사 선택 로직 구현
- 회사 구성원 삭제 api 연동
- 구성원 권한 변경 api 연동

## 📝 기타 참고 사항
- 테스트 방법, 추가로 공유할 내용

