### PR TITLE
feat(fe): 채팅방 상세 정보 보기 기능 구현

### DIFF
--- a/frontend/src/api/chat/chatApi.ts
+++ b/frontend/src/api/chat/chatApi.ts
@@ -1,4 +1,4 @@
-import type { ChatRoom, ChatMessage } from '@/types/chatTypes';
+import type { ChatRoom, ChatMessage, ChatRoomParticipant, ChatRoomDetail } from '@/types/chatTypes';
 
 import { axiosInstance } from '@/api/axiosConfig.ts';
 import { CHAT_COLORS } from '@/styles/colors.ts';
@@ -31,7 +31,16 @@ export const getChatMessages = async (orgId: number, roomId: number) => {
 };
 
 export const getChatRoomDetail = async (orgId: number, roomId: number) => {
-  const response = await axiosInstance.get<ChatRoom>(`/api/orgs/${orgId}/chat-rooms/${roomId}`);
+  const response = await axiosInstance.get<ChatRoomDetail>(
+    `/api/orgs/${orgId}/chat-rooms/${roomId}`,
+  );
+  return response.data;
+};
+
+export const getChatRoomParticipants = async (orgId: number, roomId: number) => {
+  const response = await axiosInstance.get<ChatRoomParticipant[]>(
+    `/api/orgs/${orgId}/chat-rooms/${roomId}/participants`,
+  );
   return response.data;
 };
 

--- a/frontend/src/components/chat/list/ChatRoomDetailMaodal.tsx
+++ b/frontend/src/components/chat/list/ChatRoomDetailMaodal.tsx
@@ -1,0 +1,72 @@
+import { format } from 'date-fns';
+
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { useChatRoomDetailQuery } from '@/hooks/queries/chat/useChatRoomDetailQueries';
+import { useChatRoomParticipantsQuery } from '@/hooks/queries/chat/useChatRoomParticipantsQueries';
+import { CHAT_COLORS } from '@/styles/colors';
+interface Props {
+  orgId: number;
+  roomId: number;
+  onClose: () => void;
+}
+
+export const ChatRoomDetailModal = ({ orgId, roomId, onClose }: Props) => {
+  const { data: chatRoom, isLoading } = useChatRoomDetailQuery(orgId, roomId);
+  const { data: chatRoomParticipants } = useChatRoomParticipantsQuery(orgId, roomId);
+
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader className="flex-row justify-start items-center gap-5">
+          <div>
+            {chatRoom && (
+              <div
+                className="w-7 h-7 rounded-full"
+                style={{ backgroundColor: CHAT_COLORS[chatRoom.color] }}
+              />
+            )}
+          </div>
+          <div>
+            <DialogTitle>{isLoading ? '정보를 불러오는 중...' : chatRoom?.name}</DialogTitle>
+            <DialogDescription>채팅방 상세 정보</DialogDescription>
+          </div>
+        </DialogHeader>
+        <div className="flex items-center gap-4">
+          <p className="text-sm font-medium text-muted-foreground">생성일</p>
+          <p className="text-sm">
+            {chatRoom?.createdAt ? format(new Date(chatRoom.createdAt), 'yyyy-MM-dd') : ''}
+          </p>
+        </div>
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">
+            참여자 ({chatRoomParticipants?.length ?? 0}명)
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2 p-2 bg-muted rounded-md min-h-[60px]">
+            {isLoading ? (
+              <span className="text-sm text-muted-foreground">목록을 불러오는 중...</span>
+            ) : (
+              chatRoomParticipants?.map((participant) => (
+                <Badge key={participant.memberId} variant="secondary">
+                  {participant.memberName}
+                </Badge>
+              ))
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <ButtonComponent variant="danger">나가기</ButtonComponent>
+          <ButtonComponent onClick={onClose}>닫기</ButtonComponent>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/chat/list/ChatRoomRow.tsx
+++ b/frontend/src/components/chat/list/ChatRoomRow.tsx
@@ -2,14 +2,17 @@ import { useState } from 'react';
 
 import { Popover, PopoverTrigger, PopoverContent } from '@radix-ui/react-popover';
 import { Link } from '@tanstack/react-router';
+import { Info } from 'lucide-react';
 
 import { ChatRoom } from '@/types/chatTypes';
 
-import { Button } from '@/components/ui/button';
+import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { useChatMessagesQuery } from '@/hooks/queries/chat/useChatMessagesQueries';
 import { useUpdateChatRoomQuery } from '@/hooks/queries/chat/useUpdateChatRoomQueries';
 import { CHAT_COLORS } from '@/styles/colors';
+
+import { ChatRoomDetailModal } from './ChatRoomDetailMaodal';
 
 interface Props {
   orgId: number;
@@ -19,9 +22,9 @@ interface Props {
 export const ChatRoomRow = ({ orgId, chatRoom }: Props) => {
   const { data: messages = [], isLoading } = useChatMessagesQuery(Number(orgId), chatRoom.roomId);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const latestMessage = messages[messages.length - 1]?.message ?? '메시지가 없습니다.';
   const { mutate: updateColor } = useUpdateChatRoomQuery(orgId, chatRoom.roomId);
-
   const handleColorSelect = (e: React.MouseEvent, color: keyof typeof CHAT_COLORS) => {
     e.stopPropagation();
 
@@ -37,7 +40,7 @@ export const ChatRoomRow = ({ orgId, chatRoom }: Props) => {
       <TableCell>
         <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
           <PopoverTrigger asChild>
-            <Button
+            <ButtonComponent
               variant="ghost"
               size="icon"
               onClick={() => {
@@ -56,7 +59,7 @@ export const ChatRoomRow = ({ orgId, chatRoom }: Props) => {
           >
             <div className="flex gap-2">
               {(Object.keys(CHAT_COLORS) as Array<keyof typeof CHAT_COLORS>).map((color) => (
-                <Button
+                <ButtonComponent
                   variant="ghost"
                   size="icon"
                   key={color}
@@ -70,12 +73,24 @@ export const ChatRoomRow = ({ orgId, chatRoom }: Props) => {
           </PopoverContent>
         </Popover>
       </TableCell>
-      <Link to="/org/$orgId/chat/$roomId" params={{ orgId, roomId: String(chatRoom.roomId) }}>
+      <Link
+        to="/org/$orgId/chat/$roomId"
+        params={{ orgId: String(orgId), roomId: String(chatRoom.roomId) }}
+      >
         <TableCell className="flex item-center py-4">{chatRoom.name}</TableCell>
       </Link>
       <TableCell>{isLoading ? '로딩 중...' : latestMessage}</TableCell>
       <TableCell>
-        <button>ℹ︎</button>
+        <ButtonComponent variant="ghost" size="icon" onClick={() => setIsModalOpen(true)}>
+          <Info className="h-4 w-4" />
+        </ButtonComponent>{' '}
+        {isModalOpen && (
+          <ChatRoomDetailModal
+            orgId={orgId}
+            roomId={chatRoom.roomId}
+            onClose={() => setIsModalOpen(false)}
+          />
+        )}
       </TableCell>
     </TableRow>
   );

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/frontend/src/hooks/queries/chat/useChatRoomParticipantsQueries.ts
+++ b/frontend/src/hooks/queries/chat/useChatRoomParticipantsQueries.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getChatRoomParticipants } from '@/api/chat/chatApi';
+
+export const useChatRoomParticipantsQuery = (orgId: number, roomId: number) =>
+  useQuery({
+    queryKey: ['chatRoomParticipants', orgId, roomId],
+    queryFn: () => getChatRoomParticipants(orgId, roomId),
+    enabled: !!orgId && !!roomId,
+  });

--- a/frontend/src/types/chatTypes.ts
+++ b/frontend/src/types/chatTypes.ts
@@ -1,11 +1,11 @@
-import { CHAT_COLORS } from './../styles/colors';
+import { CHAT_COLORS } from '@/styles/colors';
 export interface ChatMessage {
   chatRoomId: number;
-  chatMessageId?: number | null;
+  chatMessageId?: number;
   senderId: number;
   senderName: string;
   message: string;
-  timestamp?: string | null;
+  timestamp?: string;
 }
 export interface UseChatReturn {
   messages: ChatMessage[];
@@ -16,4 +16,18 @@ export interface ChatRoom {
   roomId: number;
   name: string;
   color: keyof typeof CHAT_COLORS;
+}
+
+export interface ChatRoomDetail {
+  roomId: number;
+  name: string;
+  color: keyof typeof CHAT_COLORS;
+  createdAt: string;
+  orgId: string;
+}
+
+export interface ChatRoomParticipant {
+  memberId: number;
+  memberName: string;
+  profileImgUrl: string;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #111 

## ✅ 작업 내용
- 채팅 목록에서 채팅방 정보를 상세 조회할 수 있는 버튼을 추가하였습니다.
- 버튼 클릭하여 `Modal`을 통해 이름, 태그 색상, 생성일자, 참여자 목록을 조회합니다.
- 수정 기능은 넣지 않고, 나가기 버튼을 통해 채팅방을 나가는 기능 추가 예정입니다.

## 📝 기타 참고 사항
- x

