### PR TITLE
feat: 채팅 참여자 초대 관련 API request 타입 수정 및 프론트엔드 기능 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
@@ -124,7 +124,7 @@ public class ChatRestController {
             @PathVariable Long roomId,
             @RequestBody ParticipantAddReqDTO request) {
 
-        chatService.addChatRoomParticipant(orgId, roomId, request.getMemberId());
+        chatService.addChatRoomParticipants(orgId, roomId, request.getMemberIds());
 
         return ResponseEntity.ok(ApiResponse.success(null, "참여자 추가에 성공했습니다."));
     }

--- a/backend/src/main/java/com/ourhour/domain/chat/dto/ParticipantAddReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/dto/ParticipantAddReqDTO.java
@@ -2,8 +2,10 @@ package com.ourhour.domain.chat.dto;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class ParticipantAddReqDTO {
 
-    private Long memberId;
+    private List<Long> memberIds;
 }

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -103,21 +103,23 @@ public class ChatService {
     }
 
     @Transactional
-    public void addChatRoomParticipant(Long orgId, Long roomId, Long memberId) {
+    public void addChatRoomParticipants(Long orgId, Long roomId, List<Long> memberIds) {
 
         ChatRoomEntity chatRoom = chatRoomRepository.findByOrgEntity_OrgIdAndRoomId(orgId, roomId)
                 .orElseThrow(ChatException::chatRoomNotFound);
 
-        boolean isOrgMember = orgParticipantMemberRepository.existsByOrgEntity_OrgIdAndMemberEntity_MemberId(orgId, memberId);
-        if (!isOrgMember) {
-            throw BusinessException.forbidden("해당 회사의 멤버가 아닙니다.");
-        }
+        memberIds.forEach(memberId -> {
+            boolean isOrgMember = orgParticipantMemberRepository.existsByOrgEntity_OrgIdAndMemberEntity_MemberId(orgId, memberId);
+            if (!isOrgMember) {
+                throw BusinessException.forbidden("해당 회사의 멤버가 아닙니다.");
+            }
 
-        MemberEntity member = memberRepository.findById(memberId)
-                .orElseThrow(() -> BusinessException.badRequest("해당 멤버를 찾을 수 없습니다."));
+            MemberEntity member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> BusinessException.badRequest("해당 멤버를 찾을 수 없습니다."));
 
-        ChatParticipantEntity newParticipant = ChatParticipantEntity.createParticipant(chatRoom, member);
-        chatParticipantRepository.save(newParticipant);
+            ChatParticipantEntity newParticipant = ChatParticipantEntity.createParticipant(chatRoom, member);
+            chatParticipantRepository.save(newParticipant);
+        });
     }
 
     @Transactional

--- a/frontend/src/components/chat/newChat/ChatRoomParticipantSelector.tsx
+++ b/frontend/src/components/chat/newChat/ChatRoomParticipantSelector.tsx
@@ -9,8 +9,7 @@ import {
   CommandList,
 } from '@/components/ui/command.tsx';
 import { Label } from '@/components/ui/label';
-import { useOrgMembersQuery } from '@/hooks/queries/org/useOrgMembersQueries';
-import { getMemberIdFromToken } from '@/utils/auth/tokenUtils';
+
 interface Props {
   members: Member[];
   selectedMembers: Member[];

--- a/frontend/src/components/chat/room/ChatParticipantAddModal.tsx
+++ b/frontend/src/components/chat/room/ChatParticipantAddModal.tsx
@@ -1,0 +1,82 @@
+import { useState, useMemo } from 'react';
+
+import { Member } from '@/types/memberTypes';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { useAddChatRoomParticipantQuery } from '@/hooks/queries/chat/useAddChatParticipantQueries';
+import { useChatRoomParticipantsQuery } from '@/hooks/queries/chat/useChatRoomParticipantsQueries';
+import { useOrgMembersQuery } from '@/hooks/queries/org/useOrgMembersQueries';
+
+import { ChatRoomParticipantSelector } from '../newChat/ChatRoomParticipantSelector';
+
+interface Props {
+  orgId: number;
+  roomId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const ChatParticipantAddModal = ({ orgId, roomId, isOpen, onClose }: Props) => {
+  const { data: allMembers } = useOrgMembersQuery(orgId);
+  const { data: currentParticipants } = useChatRoomParticipantsQuery(orgId, roomId);
+  const { mutate: addParticipants, isPending } = useAddChatRoomParticipantQuery(orgId, roomId);
+
+  const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
+
+  const membersToInvite = useMemo(() => {
+    if (!allMembers || !currentParticipants) {
+      return [];
+    }
+
+    const participantIds = new Set(currentParticipants.map((p) => p.memberId));
+    return allMembers.filter((member) => !participantIds.has(member.memberId));
+  }, [allMembers, currentParticipants]);
+
+  const handleInvite = () => {
+    if (selectedMembers.length === 0) {
+      return;
+    }
+
+    addParticipants(
+      { memberIds: selectedMembers.map((m) => m.memberId) },
+      {
+        onSuccess: () => {
+          setSelectedMembers([]);
+          onClose();
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>채팅방에 참여자 초대하기</DialogTitle>
+        </DialogHeader>
+
+        <ChatRoomParticipantSelector
+          members={membersToInvite}
+          selectedMembers={selectedMembers}
+          onChangeSelection={setSelectedMembers}
+        />
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            취소
+          </Button>
+          <Button onClick={handleInvite} disabled={isPending || selectedMembers.length === 0}>
+            {isPending ? '초대 중...' : '초대하기'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/chat/room/ChatRoomSidebarContent.tsx
+++ b/frontend/src/components/chat/room/ChatRoomSidebarContent.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Separator } from '@/components/ui/separator';
+import { SidebarContent, SidebarHeader, SidebarFooter } from '@/components/ui/sidebar';
+import { useChatRoomParticipantsQuery } from '@/hooks/queries/chat/useChatRoomParticipantsQueries';
+
+import { ChatParticipantAddModal } from './ChatParticipantAddModal';
+import { ChatRoomDeleteAlert } from '../list/ChatRoomDeleteAlert';
+interface Props {
+  orgId: number;
+  roomId: number;
+  onClose: () => void;
+}
+
+export const ChatRoomSidebarContent = ({ orgId, roomId, onClose }: Props) => {
+  const { data: participants, isLoading } = useChatRoomParticipantsQuery(orgId, roomId);
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+
+  return (
+    <>
+      <SidebarHeader className="p-4">
+        <h3 className="text-lg font-semibold">참여자 정보</h3>
+        <p className="text-sm text-muted-foreground">현재 채팅방의 전체 참여자 목록입니다.</p>
+      </SidebarHeader>
+
+      <Separator />
+
+      <SidebarContent className="flex-grow p-4">
+        <h4 className="mb-2 text-sm font-medium text-muted-foreground">
+          참여자 ({participants?.length ?? 0}명)
+        </h4>
+        <div className="space-y-2">
+          {isLoading ? (
+            <span>목록을 불러오는 중...</span>
+          ) : (
+            participants?.map((participant) => (
+              <div key={participant.memberId} className="flex items-center gap-3">
+                <Avatar className="h-8 w-8">
+                  <AvatarImage src={participant.profileImgUrl} />
+                  <AvatarFallback>{participant.memberName.charAt(0)}</AvatarFallback>
+                </Avatar>
+                <span className="font-medium">{participant.memberName}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </SidebarContent>
+
+      <Separator />
+
+      <SidebarFooter className="p-4 grid grid-cols-2 gap-2">
+        <ButtonComponent
+          variant="primary"
+          onClick={() => {
+            setIsInviteModalOpen(true);
+          }}
+        >
+          참여자 초대
+        </ButtonComponent>
+        <ChatRoomDeleteAlert orgId={orgId} roomId={roomId} onSuccess={onClose} />
+      </SidebarFooter>
+
+      {isInviteModalOpen && (
+        <ChatParticipantAddModal
+          orgId={orgId}
+          roomId={roomId}
+          isOpen={isInviteModalOpen}
+          onClose={() => setIsInviteModalOpen(false)}
+        />
+      )}
+    </>
+  );
+};

--- a/frontend/src/hooks/queries/chat/useAddChatParticipantQueries.ts
+++ b/frontend/src/hooks/queries/chat/useAddChatParticipantQueries.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { toast } from 'sonner';
-
 import { addChatParticipant, ChatParticipantAddPayload } from '@/api/chat/chatApi';
+import { showToast } from '@/utils/toast';
 
 export const useAddChatRoomParticipantQuery = (orgId: number, roomId: number) => {
   const queryClient = useQueryClient();
@@ -11,11 +10,11 @@ export const useAddChatRoomParticipantQuery = (orgId: number, roomId: number) =>
     mutationFn: (payload: ChatParticipantAddPayload) => addChatParticipant(orgId, roomId, payload),
 
     onSuccess: () => {
-      toast('✅ 채팅방 참가자 추가에 성공하였습니다.');
-      queryClient.invalidateQueries({ queryKey: ['chatRooms', orgId] });
+      showToast('success', '채팅방 참가자 추가에 성공하였습니다.');
+      queryClient.invalidateQueries({ queryKey: ['chatRoomParticipants', orgId, roomId] });
     },
     onError: () => {
-      toast('❌ 채팅방 참가자 추가에 실패하였습니다.');
+      showToast('error', '채팅방 참가자 추가에 실패하였습니다.');
     },
   });
 };

--- a/frontend/src/pages/chat/ChatRoomPage.tsx
+++ b/frontend/src/pages/chat/ChatRoomPage.tsx
@@ -2,8 +2,11 @@ import { ChatMessage } from '@/types/chatTypes.ts';
 
 import { ChatMessageInput } from '@/components/chat/room/ChatMessageInput.tsx';
 import { ChatMessageList } from '@/components/chat/room/ChatMessageList.tsx';
+import { ChatRoomSidebarContent } from '@/components/chat/room/ChatRoomSidebarContent';
 import { RenamePopover } from '@/components/chat/room/RenamePopover';
 import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Sidebar, SidebarProvider, SidebarTrigger, SidebarInset } from '@/components/ui/sidebar';
 import { useChat } from '@/hooks/queries/chat/useChat';
 import { getMemberIdFromToken } from '@/utils/auth/tokenUtils';
 interface ChatRoomPageProps {
@@ -17,20 +20,32 @@ export function ChatRoomPage({ messages, orgId, roomId }: ChatRoomPageProps) {
   const currentMemberId = getMemberIdFromToken();
 
   return (
-    <div className="bg-gray-50 py-8">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Card className="text-left mb-8 h-[70vh] flex flex-col">
-          <CardHeader>
-            <RenamePopover orgId={orgId} roomId={roomId} />
-          </CardHeader>
-          <CardContent className="bg-white rounded-lg shadow-sm p-6 overflow-y-auto grow min-h-0 w-full">
-            <ChatMessageList messages={messages} currentMemberId={currentMemberId} />
-          </CardContent>
-          <CardFooter className="w-full px-4 py-3">
-            <ChatMessageInput onSendMessage={sendMessage} />
-          </CardFooter>
-        </Card>
-      </div>
-    </div>
+    <SidebarProvider>
+      <SidebarInset>
+        <div className="bg-gray-50 py-8 h-[calc(100vh-140px)]">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 h-full">
+            <Card className="text-left h-full flex flex-col ">
+              <CardHeader className="flex-row items-center justify-between">
+                <RenamePopover orgId={orgId} roomId={roomId} />
+                <SidebarTrigger />
+              </CardHeader>
+
+              <Separator />
+
+              <CardContent className="bg-white p-6 overflow-y-auto grow min-h-0 w-full">
+                <ChatMessageList messages={messages} currentMemberId={currentMemberId} />
+              </CardContent>
+              <CardFooter className="w-full px-4 py-3 border-t">
+                <ChatMessageInput onSendMessage={sendMessage} />
+              </CardFooter>
+            </Card>
+          </div>
+        </div>
+      </SidebarInset>
+
+      <Sidebar variant="sidebar" side="right" className="mt-16 h-[calc(100vh-65px)]">
+        <ChatRoomSidebarContent orgId={orgId} roomId={roomId} onClose={() => {}} />
+      </Sidebar>
+    </SidebarProvider>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #111

## ✅ 작업 내용
- 백엔드
  - 한 번에 여러명을 추가할 수 있도록 백엔드에서 요청하는 데이터 타입을 `List`로 수정하였습니다.
- 프론트엔드
  - 채팅방 내에서 우측 사이드바 버튼을 통해 참여자 목록을 조회하고 새로운 참여자를 초대하는 기능을 추가하였습니다.
  - 참여자 초대 목록은 해당 회사의 멤버이며, 채팅에 참여중이지 않은 멤버만 조회하도록 구현하였습니다.

## 📝 기타 참고 사항
- 메뉴 버튼을(`SidebarTrigger`) 햄버거바(`Menu`)로 너무 바꾸고 싶었으나 실패하였습니다...........

