### PR TITLE
feat(be): 게시글 REST API 경로 수정 및 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/board/controller/PostController.java
+++ b/backend/src/main/java/com/ourhour/domain/board/controller/PostController.java
@@ -1,0 +1,99 @@
+package com.ourhour.domain.board.controller;
+
+import com.ourhour.domain.board.dto.PostCreateUpdateReqDTO;
+import com.ourhour.domain.board.dto.PostDTO;
+import com.ourhour.domain.board.service.PostService;
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.global.common.dto.ApiResponse;
+import com.ourhour.global.jwt.annotation.OrgAuth;
+import com.ourhour.global.jwt.annotation.OrgId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/organizations")
+public class PostController {
+
+    private final PostService postService;
+
+    // 전체 게시글 조회(게시판 구분 x)
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @GetMapping("/{orgId}/board/posts")
+    public ResponseEntity<ApiResponse<List<PostDTO>>> getAllPosts(
+            @OrgId @PathVariable Long orgId) {
+
+        List<PostDTO> allPosts = postService.getAllPosts(orgId);
+
+        return ResponseEntity.ok(ApiResponse.success(allPosts, "게시글 전체 조회에 성공했습니다."));
+
+    }
+
+    // 게시판 별 게시글 조회
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @GetMapping("/{orgId}/boards/{boardId}/posts")
+    public ResponseEntity<ApiResponse<List<PostDTO>>> getPostsByBoardId(
+            @OrgId @PathVariable Long orgId,
+            @PathVariable Long boardId) {
+
+        List<PostDTO> posts = postService.getPostsByBoardId(orgId, boardId);
+
+        return ResponseEntity.ok(ApiResponse.success(posts, "게시판 별 게시글 전체 조회에 성공했습니다."));
+    }
+
+    // 게시글 상세 조회
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @GetMapping("/{orgId}/boards/{boardId}/posts/{postId}")
+    public ResponseEntity<ApiResponse<PostDTO>> getPostById(
+            @OrgId @PathVariable Long orgId,
+            @PathVariable Long boardId,
+            @PathVariable Long postId) {
+
+        PostDTO post = postService.getPostById(orgId, boardId, postId);
+
+        return ResponseEntity.ok(ApiResponse.success(post, "게시글 상세 조회에 성공했습니다."));
+    }
+
+    // 게시글 등록
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @PostMapping("/{orgId}/boards/{boardId}/posts")
+    public ResponseEntity<ApiResponse<Void>> registPost(
+            @OrgId @PathVariable Long orgId,
+            @PathVariable Long boardId,
+            @RequestBody PostCreateUpdateReqDTO request) {
+
+        postService.createPost(orgId, boardId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "게시글 등록에 성공했습니다."));
+    }
+
+    // 게시글 수정
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @PutMapping("/{orgId}/boards/{boardId}/posts/{postId}")
+    public ResponseEntity<ApiResponse<Void>> modifyPost(
+            @OrgId @PathVariable Long orgId,
+            @PathVariable Long boardId,
+            @PathVariable Long postId,
+            @RequestBody PostCreateUpdateReqDTO request) {
+
+        postService.updatePost(orgId, boardId, postId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "게시글 수정에 성공했습니다."));
+    }
+
+    // 게시글 삭제
+    @OrgAuth(accessLevel = Role.MEMBER)
+    @DeleteMapping("/{orgId}/boards/{boardId}/posts/{postId}")
+    public ResponseEntity<ApiResponse<Void>> deletePost(
+            @OrgId @PathVariable Long orgId,
+            @PathVariable Long boardId,
+            @PathVariable Long postId) {
+
+        postService.deletePost(orgId, boardId, postId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "게시글 삭제에 성공했습니다."));
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/board/dto/PostCreateUpdateReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/board/dto/PostCreateUpdateReqDTO.java
@@ -1,0 +1,10 @@
+package com.ourhour.domain.board.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostCreateUpdateReqDTO {
+
+    private String title;
+    private String content;
+}

--- a/backend/src/main/java/com/ourhour/domain/board/entity/PostEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/board/entity/PostEntity.java
@@ -2,9 +2,7 @@ package com.ourhour.domain.board.entity;
 
 import com.ourhour.domain.member.entity.MemberEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -12,6 +10,8 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "tbl_post")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostEntity {
 
@@ -35,5 +35,10 @@ public class PostEntity {
 
     @CreationTimestamp
     private LocalDateTime createdAt;
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/board/mapper/PostMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/board/mapper/PostMapper.java
@@ -1,0 +1,20 @@
+
+package com.ourhour.domain.board.mapper;
+
+import com.ourhour.domain.board.dto.PostDTO;
+import com.ourhour.domain.board.entity.PostEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface PostMapper {
+
+
+    PostMapper INSTANCE = Mappers.getMapper(PostMapper.class);
+
+    // Entity -> DTO 매핑
+    @Mapping(source = "authorEntity.name", target = "authorName")
+    @Mapping(source = "boardEntity.boardId", target = "boardId")
+    PostDTO toDTO(PostEntity postEntity);
+}

--- a/backend/src/main/java/com/ourhour/domain/board/repository/PostRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/board/repository/PostRepository.java
@@ -1,9 +1,25 @@
 package com.ourhour.domain.board.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.ourhour.domain.board.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+@Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
+    @Query("SELECT p " +
+            "FROM PostEntity p " +
+            "WHERE p.boardEntity.orgEntity.orgId = :orgId " +
+            "ORDER BY p.createdAt DESC")
+    List<PostEntity> findAllByOrgId(Long orgId);
+
+    @Query("SELECT p FROM PostEntity p " +
+            "WHERE p.boardEntity.boardId = :boardId " +
+            "AND p.boardEntity.orgEntity.orgId = :orgId " +
+            "ORDER BY p.createdAt DESC")
+    List<PostEntity> findPostsByBoardAndOrg(Long boardId, Long orgId);
 }

--- a/backend/src/main/java/com/ourhour/domain/board/service/PostService.java
+++ b/backend/src/main/java/com/ourhour/domain/board/service/PostService.java
@@ -1,0 +1,132 @@
+package com.ourhour.domain.board.service;
+
+import com.ourhour.domain.board.dto.PostCreateUpdateReqDTO;
+import com.ourhour.domain.board.dto.PostDTO;
+import com.ourhour.domain.board.entity.BoardEntity;
+import com.ourhour.domain.board.entity.PostEntity;
+import com.ourhour.domain.board.mapper.PostMapper;
+import com.ourhour.domain.board.repository.BoardRepository;
+import com.ourhour.domain.board.repository.PostRepository;
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.repository.MemberRepository;
+import com.ourhour.global.exception.BusinessException;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.util.UserContextHolder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+    private final PostMapper postMapper;
+
+    public List<PostDTO> getAllPosts(Long orgId) {
+
+        List<PostEntity> allPosts = postRepository.findAllByOrgId(orgId);
+
+        return allPosts.stream().map(postMapper::toDTO).collect(Collectors.toList());
+    }
+
+    public List<PostDTO> getPostsByBoardId(Long orgId, Long boardId) {
+
+        List<PostEntity> posts = postRepository.findPostsByBoardAndOrg(boardId, orgId);
+
+        return posts.stream().map(postMapper::toDTO).collect(Collectors.toList());
+    }
+
+    public PostDTO getPostById(Long orgId, Long boardId, Long postId) {
+
+        PostEntity post = postRepository.findById(postId)
+                .orElseThrow(() -> BusinessException.notFound("게시글을 찾을 수 없습니다."));
+
+        if (!post.getBoardEntity().getBoardId().equals(boardId) || !post.getBoardEntity().getOrgEntity().getOrgId().equals(orgId)) {
+            throw BusinessException.forbidden("해당 게시글을 조회할 권한이 없습니다.");
+        }
+
+        return postMapper.toDTO(post);
+    }
+
+    @Transactional
+    public void createPost(Long orgId, Long boardId, PostCreateUpdateReqDTO request) {
+
+        Long currentMemberId = UserContextHolder.get().getOrgAuthorityList().stream()
+                .filter(auth -> auth.getOrgId().equals(orgId))
+                .map(auth -> auth.getMemberId())
+                .findFirst()
+                .orElseThrow(() -> BusinessException.unauthorized("작성자 정보를 찾을 수 없습니다."));
+
+        MemberEntity author = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> BusinessException.notFound("작성자를 멤버 목록에서 찾을 수 없습니다."));
+
+        BoardEntity board = boardRepository.findById(boardId)
+                .orElseThrow(() -> BusinessException.notFound("게시판을 찾을 수 없습니다."));
+
+        PostEntity newPost = PostEntity.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .authorEntity(author)
+                .boardEntity(board)
+                .build();
+
+        postRepository.save(newPost);
+    }
+
+    @Transactional
+    public void updatePost(Long orgId, Long boardId, Long postId, PostCreateUpdateReqDTO request) {
+
+        Long currentMemberId = getCurrentMemberId(orgId);
+
+        PostEntity postToUpdate = postRepository.findById(postId)
+                .orElseThrow(() -> BusinessException.notFound("수정할 게시글을 찾을 수 없습니다."));
+
+        if (!postToUpdate.getBoardEntity().getBoardId().equals(boardId) || !postToUpdate.getBoardEntity().getOrgEntity().getOrgId().equals(orgId)) {
+            throw BusinessException.forbidden("요청 경로가 올바르지 않습니다.");
+        }
+
+        if (!postToUpdate.getAuthorEntity().getMemberId().equals(currentMemberId)) {
+            throw BusinessException.forbidden("게시글을 수정할 권한이 없습니다.");
+        }
+
+        postToUpdate.update(request.getTitle(), request.getContent());
+    }
+
+    @Transactional
+    public void deletePost(Long orgId, Long boardId, Long postId) {
+
+        Long currentMemberId = getCurrentMemberId(orgId);
+
+        PostEntity postToDelete = postRepository.findById(postId)
+                .orElseThrow(() -> BusinessException.notFound("삭제할 게시글을 찾을 수 없습니다."));
+
+        if (!postToDelete.getBoardEntity().getBoardId().equals(boardId) || !postToDelete.getBoardEntity().getOrgEntity().getOrgId().equals(orgId)) {
+            throw BusinessException.forbidden("요청 경로가 올바르지 않습니다.");
+        }
+
+        if (!postToDelete.getAuthorEntity().getMemberId().equals(currentMemberId)) {
+            throw BusinessException.forbidden("게시글을 삭제할 권한이 없습니다.");
+        }
+
+        postRepository.delete(postToDelete);
+    }
+
+    private Long getCurrentMemberId(Long orgId) {
+        Claims claims = UserContextHolder.get();
+        if (claims == null) {
+            throw BusinessException.unauthorized("인증 정보를 찾을 수 없습니다.");
+        }
+
+        return claims.getOrgAuthorityList().stream()
+                .filter(auth -> auth.getOrgId().equals(orgId))
+                .map(auth -> auth.getMemberId())
+                .findFirst()
+                .orElseThrow(() -> BusinessException.forbidden("멤버 정보를 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION

## 🔗 관련 이슈
- #137

## ✅ 작업 내용
- API경로에 `organizations/{orgId}`를 추가하였습니다.
- 경로를 명확히 하기 위해 `boards/{boardId}/posts/..`로 구성하였습니다.
- 게시글 CRUD 관련 API 엔드포인트를 구현하였습니다. 
- 주요 변경 사항

## 📝 기타 참고 사항
- postman을 통해 테스트 완료하였습니다.

