### PR TITLE
feat(fe/be): 개인정보 페이지 ui 구현 및 api 연동

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/member/controller/MemberController.java
@@ -23,13 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Max;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -113,7 +107,7 @@ public class MemberController {
 
     // 회사 내 개인 정보 수정
     @OrgAuth
-    @PostMapping("/organizations/{orgId}/me")
+    @PutMapping("/organizations/{orgId}/me")
     public ResponseEntity<ApiResponse<MyMemberInfoResDTO>> updateMyMemberInfoInOrg(@OrgId @PathVariable Long orgId, @RequestBody MyMemberInfoReqDTO myMemberInfoReqDTO) {
 
         MyMemberInfoResDTO memberInfoResDTO = memberService.updateMyMemberInfoInOrg(orgId, myMemberInfoReqDTO);

--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoReqDTO.java
@@ -1,18 +1,29 @@
 package com.ourhour.domain.member.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class MyMemberInfoReqDTO {
 
     private String name;
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
     private String phone;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @Pattern(regexp = "^(https?://.*|data:image/(png|jpg|jpeg|gif|svg\\+xml);base64,.*|/images/.*)$", message = "올바른 URL, Base64 이미지 데이터, 또는 기존 이미지 경로여야 합니다")
     private String profileImgUrl;
+
     private String deptName;
     private String positionName;
 

--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
@@ -21,6 +21,6 @@ public class MyMemberInfoResDTO {
     private String profileImgUrl;
     private String deptName;
     private String positionName;
-    private Role role;
+    private String role;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
@@ -1,6 +1,5 @@
 package com.ourhour.domain.member.dto;
 
-import com.ourhour.domain.org.enums.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MyMemberInfoResDTO {
-
 
     private Long memberId;
     private Long orgId;

--- a/backend/src/main/java/com/ourhour/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.ourhour.domain.member.repository;
 
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
+import com.ourhour.domain.org.enums.Status;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.domain.Page;
@@ -29,8 +31,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
             + "JOIN opm.orgEntity o "
             + "LEFT JOIN opm.departmentEntity d "
             + "LEFT JOIN opm.positionEntity p "
-            + "WHERE m.memberId IN :memberIds")
-    Page<OrgParticipantMemberEntity> findOrgListByMemberIds(@Param("memberIds") List<Long> memberIds, Pageable pageable);
+            + "WHERE m.memberId IN :memberIds AND opm.status = com.ourhour.domain.org.enums.Status.ACTIVE")
+    Page<OrgParticipantMemberEntity> findOrgListByMemberIdsAndStatus(@Param("memberIds") List<Long> memberIds, @Param("status") Status status, Pageable pageable);
 
     /* userId로 모든 memberId 조회 */
     @Query("SELECT DISTINCT m.memberId FROM MemberEntity m WHERE m.userEntity.userId = :userId")

--- a/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
+++ b/backend/src/main/java/com/ourhour/domain/org/controller/OrgMemberController.java
@@ -61,7 +61,8 @@ public class OrgMemberController {
     // 구성원 상세 조회
     @OrgAuth
     @GetMapping("/{orgId}/members/{memberId}")
-    public ResponseEntity<ApiResponse<MemberInfoResDTO>> getOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
+    public ResponseEntity<ApiResponse<MemberInfoResDTO>> getOrgMember(@OrgId @PathVariable Long orgId,
+            @PathVariable Long memberId) {
 
         MemberInfoResDTO memberInfoResDTO = orgMemberService.getOrgMember(orgId, memberId);
 
@@ -74,7 +75,8 @@ public class OrgMemberController {
     // 구성원 권한 변경
     @OrgAuth(accessLevel = Role.ROOT_ADMIN)
     @PatchMapping("/{orgId}/members/{memberId}/role")
-    public ResponseEntity<ApiResponse<OrgMemberRoleResDTO>> getOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId, @RequestBody OrgMemberRoleReqDTO orgMemberRoleReqDTO) {
+    public ResponseEntity<ApiResponse<OrgMemberRoleResDTO>> getOrgMember(@OrgId @PathVariable Long orgId,
+            @PathVariable Long memberId, @RequestBody OrgMemberRoleReqDTO orgMemberRoleReqDTO) {
 
         OrgMemberRoleResDTO orgMemberRoleResDTO = orgMemberService.changeRole(orgId, memberId, orgMemberRoleReqDTO);
 
@@ -87,7 +89,8 @@ public class OrgMemberController {
     // 구성원 삭제
     @OrgAuth(accessLevel = Role.ROOT_ADMIN)
     @DeleteMapping("/{orgId}/members/{memberId}")
-    public ResponseEntity<ApiResponse<Void>> deleteOrgMember(@OrgId @PathVariable Long orgId, @PathVariable Long memberId) {
+    public ResponseEntity<ApiResponse<Void>> deleteOrgMember(@OrgId @PathVariable Long orgId,
+            @PathVariable Long memberId) {
 
         orgMemberService.deleteOrgMember(orgId, memberId);
 
@@ -95,6 +98,16 @@ public class OrgMemberController {
 
         return ResponseEntity.ok(apiResponse);
 
+    }
+
+    // 회사 나가기
+    @OrgAuth
+    @DeleteMapping("/{orgId}/members/me")
+    public ResponseEntity<ApiResponse<Void>> exitOrg(@OrgId @PathVariable Long orgId) {
+
+        orgMemberService.exitOrg(orgId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "회사 나가기에 성공하였습니다."));
     }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/org/mapper/OrgParticipantMemberMapper.java
@@ -26,7 +26,8 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgEntity.logoImgUrl", target = "logoImgUrl")
     @Mapping(source = "memberEntity.name", target = "memberName")
     @Mapping(target = "myRole", expression = "java(orgParticipantMemberEntity.getRole().getDescription())")
-    OrgResDTO toOrgResDTO(OrgEntity orgEntity, MemberEntity memberEntity, OrgParticipantMemberEntity orgParticipantMemberEntity);
+    OrgResDTO toOrgResDTO(OrgEntity orgEntity, MemberEntity memberEntity,
+            OrgParticipantMemberEntity orgParticipantMemberEntity);
 
     // Entity -> DTO 변환 (구성원 권한 변경)
     @Mapping(source = "orgParticipantMemberEntity.orgEntity.orgId", target = "orgId")
@@ -34,7 +35,8 @@ public interface OrgParticipantMemberMapper {
     @Mapping(target = "oldRole", expression = "java(oldRole.getDescription())")
     @Mapping(target = "newRole", expression = "java(orgParticipantMemberEntity.getRole().getDescription())")
     @Mapping(source = "rootAdminCount", target = "rootAdminCount")
-    OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole, int rootAdminCount);
+    OrgMemberRoleResDTO toOrgMemberRoleResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity, Role oldRole,
+            int rootAdminCount);
 
     // Entity -> DTO 변환 (구성원 상세 조회)
     @Mapping(source = "orgParticipantMemberEntity.memberEntity.memberId", target = "memberId")
@@ -44,20 +46,19 @@ public interface OrgParticipantMemberMapper {
     @Mapping(source = "orgParticipantMemberEntity.positionEntity.name", target = "positionName")
     @Mapping(source = "orgParticipantMemberEntity.departmentEntity.name", target = "deptName")
     @Mapping(source = "orgParticipantMemberEntity.memberEntity.profileImgUrl", target = "profileImgUrl")
-    @Mapping(source = "orgParticipantMemberEntity.role", target = "role")
+    @Mapping(target = "role", expression = "java(orgParticipantMemberEntity.getRole().getDescription())")
     MemberInfoResDTO toMemberInfoResDTO(OrgParticipantMemberEntity orgParticipantMemberEntity);
-
 
     // Enity -> DTO 변화 (회사 내 개인정보 조회)
     @Mapping(source = "opm.memberEntity.memberId", target = "memberId")
     @Mapping(source = "opm.orgEntity.orgId", target = "orgId")
-    @Mapping(source = "opm.memberEntity.name", target="name")
-    @Mapping(source = "opm.memberEntity.phone", target="phone")
-    @Mapping(source = "opm.memberEntity.email", target="email")
-    @Mapping(source = "opm.memberEntity.profileImgUrl", target="profileImgUrl")
-    @Mapping(source = "opm.departmentEntity.name", target="deptName")
-    @Mapping(source = "opm.positionEntity.name", target="positionName")
-    @Mapping(source = "opm.role", target="role")
+    @Mapping(source = "opm.memberEntity.name", target = "name")
+    @Mapping(source = "opm.memberEntity.phone", target = "phone")
+    @Mapping(source = "opm.memberEntity.email", target = "email")
+    @Mapping(source = "opm.memberEntity.profileImgUrl", target = "profileImgUrl")
+    @Mapping(source = "opm.departmentEntity.name", target = "deptName")
+    @Mapping(source = "opm.positionEntity.name", target = "positionName")
+    @Mapping(target = "role", expression = "java(opm.getRole().getDescription())")
     MyMemberInfoResDTO toMyMemberInfoResDTO(OrgParticipantMemberEntity opm);
 
 }

--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -8,7 +8,6 @@ import com.ourhour.domain.org.entity.OrgParticipantMemberId;
 
 import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.enums.Status;
-import com.ourhour.global.common.dto.PageResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,7 +15,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +53,7 @@ public interface OrgParticipantMemberRepository
     """)
     void updateDeactivateAllMembers(@Param("members") List<MemberEntity> memberEntity,
                                     @Param("inactive") Status inactive,
-                                    @Param("leftAt") LocalDateTime leftAt,
+                                    @Param("leftAt") LocalDate leftAt,
                                     @Param("active") Status active
     );
 

--- a/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
@@ -1,27 +1,21 @@
 package com.ourhour.domain.user.service;
 
 import com.ourhour.domain.auth.repository.EmailVerificationRepository;
-import com.ourhour.domain.auth.service.EmailVerificationService;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
-import com.ourhour.domain.org.entity.OrgParticipantMemberEntity;
-import com.ourhour.domain.org.enums.Role;
 import com.ourhour.domain.org.enums.Status;
 import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.domain.org.service.OrgRoleGuardService;
 import com.ourhour.domain.user.dto.PwdChangeReqDTO;
 import com.ourhour.domain.user.dto.PwdVerifyReqDTO;
 import com.ourhour.domain.user.entity.UserEntity;
-import com.ourhour.domain.user.repository.UserRepository;
 import com.ourhour.domain.user.util.PasswordChanger;
 import com.ourhour.domain.user.util.PasswordVerifier;
-import com.ourhour.global.jwt.annotation.OrgAuth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.ourhour.domain.user.exception.UserException.*;
@@ -86,7 +80,7 @@ public class UserService {
 
         // 탈퇴한 사용자가 속한 모든 회사의 활성상태 INACTIVE 처리
         if (!memberEntityList.isEmpty()) {
-            LocalDateTime now = LocalDateTime.now();
+            LocalDate now = LocalDate.now();
 
             orgParticipantMemberRepository
                     .updateDeactivateAllMembers(memberEntityList, Status.INACTIVE, now, Status.ACTIVE);

--- a/frontend/src/api/auth/deleteSignout.ts
+++ b/frontend/src/api/auth/deleteSignout.ts
@@ -3,6 +3,8 @@ import { AxiosError } from 'axios';
 import { ApiResponse } from '@/types/apiTypes';
 
 import { logout } from '@/stores/authSlice';
+import { clearAllMemberNames } from '@/stores/memberSlice';
+import { clearCurrentProjectName } from '@/stores/projectSlice';
 import { logError } from '@/utils/auth/errorUtils';
 
 import { axiosInstance } from '../axiosConfig';
@@ -12,6 +14,8 @@ const postSignout = async (): Promise<ApiResponse<void>> => {
     const response = await axiosInstance.post('/api/auth/signout');
 
     logout();
+    clearAllMemberNames();
+    clearCurrentProjectName();
 
     return response.data;
   } catch (error: unknown) {

--- a/frontend/src/api/member/deleteQuitOrg.ts
+++ b/frontend/src/api/member/deleteQuitOrg.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface DeleteQuitOrgRequest {
+  orgId: number;
+}
+
+const deleteQuitOrg = async (request: DeleteQuitOrgRequest): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.delete(`/api/organizations/${request.orgId}/members/me`);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default deleteQuitOrg;

--- a/frontend/src/api/member/getMyMemberInfo.ts
+++ b/frontend/src/api/member/getMyMemberInfo.ts
@@ -6,26 +6,22 @@ import { MemberRoleKo } from '@/types/memberTypes';
 import { axiosInstance } from '@/api/axiosConfig';
 import { logError } from '@/utils/auth/errorUtils';
 
+import { MemberInfoBase } from './putUpdateMyMemberInfo';
+
 interface GetMyMemberInfoRequest {
   orgId: number;
 }
 
-export interface MyMemberInfo {
+export interface MyMemberInfoDetail extends MemberInfoBase {
   userId: number;
   memberId: number;
   orgId: number;
-  name: string;
-  phone: string;
-  email: string;
-  profileImgUrl: string;
-  deptName: string;
-  positionName: string;
   role: MemberRoleKo;
 }
 
 const getMyMemberInfo = async (
   request: GetMyMemberInfoRequest,
-): Promise<ApiResponse<MyMemberInfo>> => {
+): Promise<ApiResponse<MyMemberInfoDetail>> => {
   try {
     const response = await axiosInstance.get(`/api/members/organizations/${request.orgId}/me`);
     return response.data;

--- a/frontend/src/api/member/getMyMemberInfo.ts
+++ b/frontend/src/api/member/getMyMemberInfo.ts
@@ -1,0 +1,38 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+import { MemberRoleKo } from '@/types/memberTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+interface GetMyMemberInfoRequest {
+  orgId: number;
+}
+
+export interface MyMemberInfo {
+  userId: number;
+  memberId: number;
+  orgId: number;
+  name: string;
+  phone: string;
+  email: string;
+  profileImgUrl: string;
+  deptName: string;
+  positionName: string;
+  role: MemberRoleKo;
+}
+
+const getMyMemberInfo = async (
+  request: GetMyMemberInfoRequest,
+): Promise<ApiResponse<MyMemberInfo>> => {
+  try {
+    const response = await axiosInstance.get(`/api/members/organizations/${request.orgId}/me`);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default getMyMemberInfo;

--- a/frontend/src/api/member/patchPasswordChange.ts
+++ b/frontend/src/api/member/patchPasswordChange.ts
@@ -1,0 +1,26 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface PatchPasswordChangeRequest {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordCheck: string;
+}
+
+const patchPasswordChange = async (
+  request: PatchPasswordChangeRequest,
+): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.patch('/api/user/password', request);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default patchPasswordChange;

--- a/frontend/src/api/member/putUpdateMyMemberInfo.ts
+++ b/frontend/src/api/member/putUpdateMyMemberInfo.ts
@@ -1,0 +1,35 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { MyMemberInfoDetail } from '@/api/member/getMyMemberInfo';
+import { logError } from '@/utils/auth/errorUtils';
+
+interface PutUpdateMyMemberInfoRequest extends MemberInfoBase {
+  orgId: number;
+}
+
+export interface MemberInfoBase {
+  name: string;
+  phone: string | null;
+  email: string | null;
+  profileImgUrl: string | null;
+  deptName: string | null;
+  positionName: string | null;
+}
+
+const putUpdateMyMemberInfo = async (
+  request: PutUpdateMyMemberInfoRequest,
+): Promise<ApiResponse<MyMemberInfoDetail>> => {
+  const { orgId, ...requestBody } = request;
+  try {
+    const response = await axiosInstance.put(`/api/members/organizations/${orgId}/me`, requestBody);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default putUpdateMyMemberInfo;

--- a/frontend/src/api/org/getOrgInfo.ts
+++ b/frontend/src/api/org/getOrgInfo.ts
@@ -15,9 +15,9 @@ export interface OrgBaseInfo {
   address: string;
   email: string;
   representativeName: string;
-  phone: string;
+  phone: string | null;
   businessNumber: string;
-  logoImgUrl: string;
+  logoImgUrl: string | null;
 }
 
 const getOrgInfo = async (request: GetOrgInfoRequest): Promise<ApiResponse<OrgBaseInfo>> => {

--- a/frontend/src/api/org/postCreateOrg.ts
+++ b/frontend/src/api/org/postCreateOrg.ts
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios';
 
 import { ApiResponse } from '@/types/apiTypes';
+import { MemberRoleKo } from '@/types/memberTypes';
 
 import { axiosInstance } from '@/api/axiosConfig';
 import { OrgBaseInfo } from '@/api/org/getOrgInfo';
@@ -19,7 +20,7 @@ export interface PostCreateOrgRequest {
 
 export interface PostCreateOrgResponse extends OrgBaseInfo {
   memberName: string;
-  myRole: string;
+  myRole: MemberRoleKo;
 }
 
 const postCreateOrg = async (

--- a/frontend/src/api/user/deleteUser.ts
+++ b/frontend/src/api/user/deleteUser.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface DeleteUserRequest {
+  password: string;
+}
+
+const deleteUser = async (request: DeleteUserRequest): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.delete('/api/user', {
+      data: request,
+    });
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default deleteUser;

--- a/frontend/src/components/common/info-menu/ProfileSheet.tsx
+++ b/frontend/src/components/common/info-menu/ProfileSheet.tsx
@@ -1,41 +1,37 @@
 import { useState } from 'react';
 
+import { useLocation } from '@tanstack/react-router';
 import { User, LogOut, Settings } from 'lucide-react';
 
+import { MyMemberInfo } from '@/api/member/getMyMemberInfo';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/sheet';
+import { MEMBER_ROLE_STYLES } from '@/constants/badges';
 import { useSignoutMutation } from '@/hooks/queries/auth/useAuthMutations';
+import useMyMemberInfoQuery from '@/hooks/queries/member/useMyMemberInfoQuery';
 
 interface ProfileSheetProps {
   children: React.ReactNode;
 }
 
-interface UserProfile {
-  name: string;
-  company: string;
-  department: string;
-  position: string;
-  email: string;
-  phone: string;
-  profileImage?: string;
-}
-
-const mockUserProfile: UserProfile = {
-  name: 'Jane Doe',
-  company: '회사명',
-  department: '개발 1팀',
-  position: '사원',
-  email: 'ddzeun@gmail.com',
-  phone: '010-1234-5678',
-};
-
 export function ProfileSheet({ children }: ProfileSheetProps) {
   const [isOpen, setIsOpen] = useState(false);
+
+  const location = useLocation();
+  const orgId = location.pathname.split('/')[2];
+
+  const { data: myMemberInfoData } = useMyMemberInfoQuery({ orgId: Number(orgId) });
+  const myMemberInfo = myMemberInfoData as unknown as MyMemberInfo;
 
   const { mutate: logout } = useSignoutMutation();
 
   const handleLogout = () => {
-    logout();
+    logout(undefined, {
+      onSuccess: () => {
+        setIsOpen(false);
+        window.location.href = '/';
+      },
+    });
   };
 
   const handleProfileManagement = () => {
@@ -47,6 +43,7 @@ export function ProfileSheet({ children }: ProfileSheetProps) {
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>{children}</SheetTrigger>
       <SheetContent side="right" className="w-80 p-0" onOpenAutoFocus={(e) => e.preventDefault()}>
+        <SheetTitle className="sr-only">프로필 정보</SheetTitle>
         <div className="flex flex-col h-full">
           <div className="flex-1 p-6">
             <div className="flex flex-col items-center space-y-4">
@@ -54,30 +51,36 @@ export function ProfileSheet({ children }: ProfileSheetProps) {
                 <User className="w-8 h-8 text-gray-400" />
               </div>
 
-              <h2 className="text-xl font-semibold text-center">{mockUserProfile.name}</h2>
+              <h2 className="text-xl font-semibold text-center">{myMemberInfo?.name}</h2>
             </div>
 
             <div className="border-t border-gray-200 my-6" />
 
             <div className="space-y-4">
               <div>
-                <p className="text-sm text-gray-600">{mockUserProfile.company}</p>
-              </div>
-              <div>
                 <p className="text-sm text-gray-600">
-                  {mockUserProfile.department ? mockUserProfile.department : ''}
+                  {myMemberInfo?.deptName ? myMemberInfo.deptName : ''}
                 </p>
               </div>
               <div>
                 <p className="text-sm text-gray-600">
-                  {mockUserProfile.position ? mockUserProfile.position : ''}
+                  {myMemberInfo?.positionName ? myMemberInfo.positionName : ''}
                 </p>
               </div>
               <div>
-                <p className="text-sm text-gray-600">{mockUserProfile.email}</p>
+                <p
+                  className={`w-fit rounded-full px-2 py-1 text-sm ${MEMBER_ROLE_STYLES[myMemberInfo?.role as keyof typeof MEMBER_ROLE_STYLES]}`}
+                >
+                  {myMemberInfo?.role ? myMemberInfo.role : ''}
+                </p>
               </div>
               <div>
-                <p className="text-sm text-gray-600">{mockUserProfile.phone}</p>
+                <p className="text-sm text-gray-600">{myMemberInfo?.email}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">
+                  {myMemberInfo?.phone ? myMemberInfo.phone : ''}
+                </p>
               </div>
             </div>
           </div>

--- a/frontend/src/components/common/info-menu/ProfileSheet.tsx
+++ b/frontend/src/components/common/info-menu/ProfileSheet.tsx
@@ -9,6 +9,7 @@ import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/s
 import { MEMBER_ROLE_STYLES } from '@/constants/badges';
 import { useSignoutMutation } from '@/hooks/queries/auth/useAuthMutations';
 import useMyMemberInfoQuery from '@/hooks/queries/member/useMyMemberInfoQuery';
+import { getImageUrl } from '@/utils/file/imageUtils';
 
 interface ProfileSheetProps {
   children: React.ReactNode;
@@ -49,9 +50,23 @@ export function ProfileSheet({ children }: ProfileSheetProps) {
         <div className="flex flex-col h-full">
           <div className="flex-1 p-6">
             <div className="flex flex-col items-center space-y-4">
-              <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center">
-                <User className="w-8 h-8 text-gray-400" />
-              </div>
+              {myMemberInfo?.profileImgUrl ? (
+                <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center">
+                  <img
+                    src={getImageUrl(myMemberInfo.profileImgUrl)}
+                    alt={myMemberInfo?.name ?? ''}
+                    width={32}
+                    height={32}
+                    className="w-full h-full object-contain bg-white rounded-full"
+                  />
+                </div>
+              ) : (
+                <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center">
+                  <span className="font-bold text-sm text-black">
+                    {myMemberInfo?.name?.charAt(0).toUpperCase() ?? ''}
+                  </span>
+                </div>
+              )}
 
               <h2 className="text-xl font-semibold text-center">{myMemberInfo?.name}</h2>
             </div>

--- a/frontend/src/components/common/info-menu/ProfileSheet.tsx
+++ b/frontend/src/components/common/info-menu/ProfileSheet.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
+import { useState } from 'react';
 
 import { User, LogOut, Settings } from 'lucide-react';
 
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
+import { useSignoutMutation } from '@/hooks/queries/auth/useAuthMutations';
 
 interface ProfileSheetProps {
   children: React.ReactNode;
@@ -29,11 +30,12 @@ const mockUserProfile: UserProfile = {
 };
 
 export function ProfileSheet({ children }: ProfileSheetProps) {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { mutate: logout } = useSignoutMutation();
 
   const handleLogout = () => {
-    console.log('로그아웃');
-    // 로그아웃 로직 구현
+    logout();
   };
 
   const handleProfileManagement = () => {

--- a/frontend/src/components/common/info-menu/ProfileSheet.tsx
+++ b/frontend/src/components/common/info-menu/ProfileSheet.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
-import { useLocation } from '@tanstack/react-router';
+import { useLocation, useRouter } from '@tanstack/react-router';
 import { User, LogOut, Settings } from 'lucide-react';
 
-import { MyMemberInfo } from '@/api/member/getMyMemberInfo';
+import { MyMemberInfoDetail } from '@/api/member/getMyMemberInfo';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@/components/ui/sheet';
 import { MEMBER_ROLE_STYLES } from '@/constants/badges';
@@ -16,12 +16,13 @@ interface ProfileSheetProps {
 
 export function ProfileSheet({ children }: ProfileSheetProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
 
   const location = useLocation();
   const orgId = location.pathname.split('/')[2];
 
   const { data: myMemberInfoData } = useMyMemberInfoQuery({ orgId: Number(orgId) });
-  const myMemberInfo = myMemberInfoData as unknown as MyMemberInfo;
+  const myMemberInfo = myMemberInfoData as unknown as MyMemberInfoDetail;
 
   const { mutate: logout } = useSignoutMutation();
 
@@ -35,8 +36,9 @@ export function ProfileSheet({ children }: ProfileSheetProps) {
   };
 
   const handleProfileManagement = () => {
-    console.log('개인 정보 관리');
-    // 개인 정보 관리 페이지로 이동
+    router.navigate({
+      to: '/info/password',
+    });
   };
 
   return (

--- a/frontend/src/components/common/left-sidebar/NavMain.tsx
+++ b/frontend/src/components/common/left-sidebar/NavMain.tsx
@@ -27,7 +27,8 @@ export function NavMain({
     isActive?: boolean;
     items?: {
       title: string;
-      url: string;
+      url?: string;
+      onClick?: () => void;
       leftIcon?: React.ComponentType;
       rightIcon?: React.ComponentType;
       onEdit?: () => void;
@@ -57,10 +58,10 @@ export function NavMain({
                 <SidebarMenuSub>
                   {item.items && item.items.length > 0 ? (
                     item.items.map((subItem) => (
-                      <SidebarMenuSubItem key={subItem.title}>
+                      <SidebarMenuSubItem key={subItem.title} onClick={subItem.onClick}>
                         <div className="flex items-center w-full">
                           <SidebarMenuSubButton asChild className="flex-1">
-                            <Link to={subItem.url}>
+                            <Link to={subItem.url ?? ''}>
                               {subItem.leftIcon && <subItem.leftIcon />}
                               <span>{subItem.title}</span>
                             </Link>

--- a/frontend/src/components/common/left-sidebar/NavMain.tsx
+++ b/frontend/src/components/common/left-sidebar/NavMain.tsx
@@ -26,6 +26,7 @@ export function NavMain({
     icon?: LucideIcon | React.ComponentType;
     isActive?: boolean;
     items?: {
+      id?: number;
       title: string;
       url?: string;
       onClick?: () => void;
@@ -58,7 +59,7 @@ export function NavMain({
                 <SidebarMenuSub>
                   {item.items && item.items.length > 0 ? (
                     item.items.map((subItem) => (
-                      <SidebarMenuSubItem key={subItem.title} onClick={subItem.onClick}>
+                      <SidebarMenu key={subItem.id} onClick={subItem.onClick}>
                         <div className="flex items-center w-full">
                           <SidebarMenuSubButton asChild className="flex-1">
                             <Link to={subItem.url ?? ''}>
@@ -79,7 +80,7 @@ export function NavMain({
                             />
                           )}
                         </div>
-                      </SidebarMenuSubItem>
+                      </SidebarMenu>
                     ))
                   ) : (
                     <SidebarMenuSubItem>

--- a/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
+++ b/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
@@ -1,69 +1,118 @@
 'use client';
 
 import * as React from 'react';
+import { useState } from 'react';
 
 import { Plus, UserCog, FileCog } from 'lucide-react';
 
 import { NavMain } from '@/components/common/left-sidebar/NavMain';
+import { OrgFormData, OrgModal } from '@/components/org/OrgModal';
 import { Sidebar, SidebarContent, SidebarRail } from '@/components/ui/sidebar';
+import useMyOrgListQuery from '@/hooks/queries/member/useMyOrgListQuery';
+import { useOrgCreateMutation } from '@/hooks/queries/org/useOrgCreateMutation';
+import { showSuccessToast } from '@/utils/toast';
 
 const PlusIcon = () => <Plus className="h-4 w-4" />;
 const UserCogIcon = () => <UserCog className="h-4 w-4" />;
 const FileCogIcon = () => <FileCog className="h-4 w-4" />;
 
-const data = {
-  navMain: [
-    {
-      title: '계정 관리',
-      url: '#',
-      icon: UserCogIcon,
-      isActive: true,
-      items: [
-        {
-          title: '계정 정보 수정',
-          url: '#',
-        },
-        {
-          title: '계정 탈퇴',
-          url: '#',
-        },
-      ],
-    },
-    {
-      title: '회사 내 개인정보 관리',
-      url: '#',
-      icon: FileCogIcon,
-      isActive: true,
-      items: [
-        {
-          title: '새 회사 등록하기',
-          leftIcon: PlusIcon,
-          url: '#',
-        },
-        {
-          title: '회사1',
-          url: '#',
-        },
-        {
-          title: '회사2',
-          url: '#',
-        },
-        {
-          title: '회사3',
-          url: '#',
-        },
-      ],
-    },
-  ],
-};
-
 export function SettingSidebarComponent({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const [isCreateOrgModalOpen, setIsCreateOrgModalOpen] = useState(false);
+
+  const { mutate: createOrg } = useOrgCreateMutation();
+
+  const { data: myOrgList } = useMyOrgListQuery({
+    currentPage: 1,
+    size: 100,
+  });
+
+  const currentOrgs = Array.isArray(myOrgList?.data)
+    ? myOrgList.data
+    : (myOrgList?.data?.data ?? []);
+
+  const handleClose = () => {
+    setIsCreateOrgModalOpen(false);
+  };
+
+  const handleOrgModalSubmit = async (data: OrgFormData) => {
+    try {
+      await createOrg({
+        memberName: data.memberName,
+        name: data.name,
+        address: data.address === '' ? null : data.address,
+        email: data.email === '' ? null : data.email,
+        phone: data.phone === '' ? null : data.phone,
+        representativeName: data.representativeName === '' ? null : data.representativeName,
+        businessNumber: data.businessNumber === '' ? null : data.businessNumber,
+        logoImgUrl: data.logoImgUrl === '' ? null : data.logoImgUrl,
+      });
+      showSuccessToast('회사 생성 완료');
+      setIsCreateOrgModalOpen(false);
+
+      // 페이지 새로고침(임시)
+      window.location.reload();
+    } catch (error) {
+      // 에러 토스트
+    }
+  };
+
+  const data = {
+    navMain: [
+      {
+        title: '계정 관리',
+        url: '#',
+        icon: UserCogIcon,
+        isActive: true,
+        items: [
+          {
+            title: '비밀번호 변경',
+            url: '/info/password',
+          },
+          {
+            title: '계정 탈퇴',
+            url: '/info/withdraw',
+          },
+        ],
+      },
+      {
+        title: '회사 내 개인정보 관리',
+        url: '#',
+        icon: FileCogIcon,
+        isActive: true,
+        items: [
+          {
+            title: '새 회사 등록하기',
+            leftIcon: PlusIcon,
+            onClick: () => {
+              setIsCreateOrgModalOpen(true);
+            },
+          },
+
+          ...currentOrgs.map((org) => ({
+            title: org.name,
+            leftIcon: UserCogIcon,
+            url: `/info/${org.orgId}`,
+          })),
+        ],
+      },
+    ],
+  };
+
   return (
-    <Sidebar collapsible="icon" className="mt-16" {...props}>
-      <SidebarContent>
-        <NavMain items={data.navMain} />
-      </SidebarContent>
-      <SidebarRail />
-    </Sidebar>
+    <>
+      <Sidebar collapsible="icon" className="mt-16" {...props}>
+        <SidebarContent>
+          <NavMain items={data.navMain} />
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+      {isCreateOrgModalOpen && (
+        <OrgModal
+          isOpen={isCreateOrgModalOpen}
+          onClose={handleClose}
+          onSubmit={handleOrgModalSubmit}
+        />
+      )}
+    </>
   );
 }

--- a/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
+++ b/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 
-import { Plus, UserCog, FileCog } from 'lucide-react';
+import { Plus, Contact, FileCog } from 'lucide-react';
 
 import { NavMain } from '@/components/common/left-sidebar/NavMain';
 import { OrgFormData, OrgModal } from '@/components/org/OrgModal';
@@ -13,7 +13,7 @@ import { useOrgCreateMutation } from '@/hooks/queries/org/useOrgCreateMutation';
 import { showSuccessToast } from '@/utils/toast';
 
 const PlusIcon = () => <Plus className="h-4 w-4" />;
-const UserCogIcon = () => <UserCog className="h-4 w-4" />;
+const ContactIcon = () => <Contact className="h-4 w-4" />;
 const FileCogIcon = () => <FileCog className="h-4 w-4" />;
 
 export function SettingSidebarComponent({ ...props }: React.ComponentProps<typeof Sidebar>) {
@@ -61,7 +61,7 @@ export function SettingSidebarComponent({ ...props }: React.ComponentProps<typeo
       {
         title: '계정 관리',
         url: '#',
-        icon: UserCogIcon,
+        icon: ContactIcon,
         isActive: true,
         items: [
           {
@@ -90,7 +90,7 @@ export function SettingSidebarComponent({ ...props }: React.ComponentProps<typeo
 
           ...currentOrgs.map((org) => ({
             title: org.name,
-            leftIcon: UserCogIcon,
+            leftIcon: Contact,
             url: `/info/${org.orgId}`,
           })),
         ],

--- a/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
+++ b/frontend/src/components/common/left-sidebar/SettingSidebarComponent.tsx
@@ -89,6 +89,7 @@ export function SettingSidebarComponent({ ...props }: React.ComponentProps<typeo
           },
 
           ...currentOrgs.map((org) => ({
+            id: org.orgId,
             title: org.name,
             leftIcon: Contact,
             url: `/info/${org.orgId}`,

--- a/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
+++ b/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
-import { useLocation, useNavigate } from '@tanstack/react-router';
-import { Bell, Menu, Users, X } from 'lucide-react';
+import { useLocation, useRouter } from '@tanstack/react-router';
+import { Bell, Menu, Users } from 'lucide-react';
 
+import logo from '@/assets/images/logo.png';
 import { ProfileSheet } from '@/components/common/info-menu/ProfileSheet';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,21 +19,22 @@ export function NavigationMenuComponent({ isInfoPage }: { isInfoPage: boolean })
 
   const [isActive, setIsActive] = useState('');
 
-  const navigate = useNavigate();
+  const router = useRouter();
 
   const handleNavigate = (path: string, orgId: string) => {
-    navigate({ to: path, params: { orgId } });
+    router.navigate({ to: path, params: { orgId } });
   };
 
   return (
     <div className="w-full border-b bg-background fixed top-0 z-50">
       <div className="w-full px-4 py-3">
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-2">
-            <div className="flex items-center justify-center w-8 h-8 bg-primary rounded">
-              <X className="w-4 h-4 text-primary-foreground" />
-            </div>
-            <span className="text-lg font-semibold">ourHour</span>
+          <div
+            className="flex items-center space-x-2 cursor-pointer"
+            onClick={() => router.navigate({ to: '/start', search: { page: 1 } })}
+          >
+            <img src={logo} alt="OurHour Logo" className="w-10 h-10" />
+            <span className="text-xl font-bold text-[#467599]">OURHOUR</span>
           </div>
 
           {!isInfoPage && (

--- a/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
+++ b/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useLocation, useNavigate } from '@tanstack/react-router';
 import { Bell, Menu, Users, X } from 'lucide-react';
 
+import { ProfileSheet } from '@/components/common/info-menu/ProfileSheet';
 import { Button } from '@/components/ui/button';
 import {
   NavigationMenu,
@@ -10,8 +11,6 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
 } from '@/components/ui/navigation-menu';
-
-import { ProfileSheet } from '../ProfileSheet';
 
 export function NavigationMenuComponent() {
   const location = useLocation();

--- a/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
+++ b/frontend/src/components/common/navigation-menu/NavigationMenuComponent.tsx
@@ -12,7 +12,7 @@ import {
   NavigationMenuList,
 } from '@/components/ui/navigation-menu';
 
-export function NavigationMenuComponent() {
+export function NavigationMenuComponent({ isInfoPage }: { isInfoPage: boolean }) {
   const location = useLocation();
   const orgId = location.pathname.split('/')[2];
 
@@ -35,76 +35,80 @@ export function NavigationMenuComponent() {
             <span className="text-lg font-semibold">ourHour</span>
           </div>
 
-          <NavigationMenu>
-            <NavigationMenuList className="flex gap-2">
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
-                    isActive === 'project' ? 'text-black' : 'text-gray-500'
-                  }`}
-                  onClick={() => {
-                    handleNavigate('/org/$orgId/project', orgId);
-                    setIsActive('project');
-                  }}
-                >
-                  프로젝트
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
-                    isActive === 'board' ? 'text-black' : 'text-gray-500'
-                  }`}
-                  onClick={() => {
-                    handleNavigate('/org/$orgId/board', orgId);
-                    setIsActive('board');
-                  }}
-                >
-                  게시판
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
-                    isActive === 'mail' ? 'text-black' : 'text-gray-500'
-                  }`}
-                  onClick={() => {
-                    handleNavigate('/org/$orgId/mail', orgId);
-                    setIsActive('mail');
-                  }}
-                >
-                  메일
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-              <NavigationMenuItem>
-                <NavigationMenuLink
-                  className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
-                    isActive === 'chat' ? 'text-black' : 'text-gray-500'
-                  }`}
-                  onClick={() => {
-                    handleNavigate('/org/$orgId/chat', orgId);
-                    setIsActive('chat');
-                  }}
-                >
-                  채팅
-                </NavigationMenuLink>
-              </NavigationMenuItem>
-            </NavigationMenuList>
-          </NavigationMenu>
+          {!isInfoPage && (
+            <NavigationMenu>
+              <NavigationMenuList className="flex gap-2">
+                <NavigationMenuItem>
+                  <NavigationMenuLink
+                    className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
+                      isActive === 'project' ? 'text-black' : 'text-gray-500'
+                    }`}
+                    onClick={() => {
+                      handleNavigate('/org/$orgId/project', orgId);
+                      setIsActive('project');
+                    }}
+                  >
+                    프로젝트
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+                <NavigationMenuItem>
+                  <NavigationMenuLink
+                    className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
+                      isActive === 'board' ? 'text-black' : 'text-gray-500'
+                    }`}
+                    onClick={() => {
+                      handleNavigate('/org/$orgId/board', orgId);
+                      setIsActive('board');
+                    }}
+                  >
+                    게시판
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+                <NavigationMenuItem>
+                  <NavigationMenuLink
+                    className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
+                      isActive === 'mail' ? 'text-black' : 'text-gray-500'
+                    }`}
+                    onClick={() => {
+                      handleNavigate('/org/$orgId/mail', orgId);
+                      setIsActive('mail');
+                    }}
+                  >
+                    메일
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+                <NavigationMenuItem>
+                  <NavigationMenuLink
+                    className={`text-sm font-medium cursor-pointer px-4 py-2 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground ${
+                      isActive === 'chat' ? 'text-black' : 'text-gray-500'
+                    }`}
+                    onClick={() => {
+                      handleNavigate('/org/$orgId/chat', orgId);
+                      setIsActive('chat');
+                    }}
+                  >
+                    채팅
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+              </NavigationMenuList>
+            </NavigationMenu>
+          )}
 
-          <div className="flex items-center space-x-2">
-            <Button variant="ghost" size="icon">
-              <Users className="w-4 h-4" />
-            </Button>
-            <Button variant="ghost" size="icon" className="relative">
-              <Bell className="w-4 h-4" />
-            </Button>
-            <ProfileSheet>
+          {!isInfoPage && (
+            <div className="flex items-center space-x-2">
               <Button variant="ghost" size="icon">
-                <Menu className="w-4 h-4" />
+                <Users className="w-4 h-4" />
               </Button>
-            </ProfileSheet>
-          </div>
+              <Button variant="ghost" size="icon" className="relative">
+                <Bell className="w-4 h-4" />
+              </Button>
+              <ProfileSheet>
+                <Button variant="ghost" size="icon">
+                  <Menu className="w-4 h-4" />
+                </Button>
+              </ProfileSheet>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/member/MemberInfoForm.tsx
+++ b/frontend/src/components/member/MemberInfoForm.tsx
@@ -1,0 +1,58 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface MemberInfoFormProps {
+  formData: {
+    name: string;
+    email: string | null;
+    deptName: string | null;
+    positionName: string | null;
+    phone: string | null;
+  };
+  onInputChange: (field: string, value: string) => void;
+}
+
+export function MemberInfoForm({ formData, onInputChange }: MemberInfoFormProps) {
+  return (
+    <div className="space-y-6 w-full max-w-lg">
+      <div className="space-y-2">
+        <Label htmlFor="name" className="text-sm font-medium">
+          활동 이름
+        </Label>
+        <Input
+          id="name"
+          placeholder="활동 이름을 입력하세요"
+          value={formData.name}
+          onChange={(e) => onInputChange('name', e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center space-x-2">
+          <Label htmlFor="phone" className="text-sm font-medium">
+            전화번호
+          </Label>
+        </div>
+        <Input
+          id="phone"
+          placeholder="전화번호를 입력하세요 (ex. 010-1234-5678)"
+          value={formData.phone ?? ''}
+          onChange={(e) => onInputChange('phone', e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="email" className="text-sm font-medium">
+          이메일
+        </Label>
+        <Input
+          id="email"
+          placeholder="이메일을 입력하세요"
+          value={formData.email ?? ''}
+          onChange={(e) => onInputChange('email', e.target.value)}
+        />
+      </div>
+      {/* 부서 및 직책 드롭다운 */}
+    </div>
+  );
+}

--- a/frontend/src/components/member/PasswordChangeForm.tsx
+++ b/frontend/src/components/member/PasswordChangeForm.tsx
@@ -1,0 +1,55 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface PasswordChangeFormProps {
+  formData: {
+    currentPassword: string;
+    newPassword: string;
+    newPasswordCheck: string;
+  };
+  onInputChange: (field: string, value: string) => void;
+}
+
+export function PasswordChangeForm({ formData, onInputChange }: PasswordChangeFormProps) {
+  return (
+    <div className="space-y-6 w-full max-w-lg">
+      <div className="space-y-2">
+        <Label htmlFor="newPassword" className="text-sm font-medium">
+          기존 비밀번호
+        </Label>
+        <Input
+          id="currentPassword"
+          type="password"
+          placeholder="기존 비밀번호를 입력하세요"
+          value={formData.currentPassword}
+          onChange={(e) => onInputChange('currentPassword', e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="newPassword" className="text-sm font-medium">
+          새 비밀번호
+        </Label>
+        <Input
+          id="newPassword"
+          type="password"
+          placeholder="새 비밀번호를 입력하세요"
+          value={formData.newPassword}
+          onChange={(e) => onInputChange('newPassword', e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="newPasswordCheck" className="text-sm font-medium">
+          새 비밀번호 확인
+        </Label>
+        <Input
+          id="newPasswordCheck"
+          type="password"
+          placeholder="새 비밀번호를 다시 입력하세요"
+          value={formData.newPasswordCheck}
+          onChange={(e) => onInputChange('newPasswordCheck', e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/member/WithdrawConfirmModal.tsx
+++ b/frontend/src/components/member/WithdrawConfirmModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { ModalComponent } from '@/components/common/ModalComponent';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { showErrorToast } from '@/utils/toast';
+
+interface WithdrawConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (password: string) => void;
+  isLoading?: boolean;
+}
+
+export function WithdrawConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  isLoading = false,
+}: WithdrawConfirmModalProps) {
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!password.trim()) {
+      showErrorToast('비밀번호를 입력해주세요.');
+      return;
+    }
+
+    onConfirm(password);
+  };
+
+  const handleClose = () => {
+    setPassword('');
+    onClose();
+  };
+
+  return (
+    <ModalComponent
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="계정 탈퇴 확인"
+      description="계정 탈퇴를 위해 비밀번호를 입력해주세요."
+      size="md"
+      footer={
+        <div className="flex gap-2 w-full">
+          <ButtonComponent
+            variant="ghost"
+            onClick={handleClose}
+            className="flex-1"
+            disabled={isLoading}
+          >
+            취소
+          </ButtonComponent>
+          <ButtonComponent
+            variant="danger"
+            onClick={handleSubmit}
+            className="flex-1"
+            disabled={isLoading}
+          >
+            {isLoading ? <LoadingSpinner size="sm" /> : '탈퇴하기'}
+          </ButtonComponent>
+        </div>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="password" className="text-sm font-medium">
+            비밀번호
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="비밀번호를 입력하세요"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={isLoading}
+            autoFocus
+          />
+        </div>
+      </form>
+    </ModalComponent>
+  );
+}

--- a/frontend/src/components/org/LogoUpload.tsx
+++ b/frontend/src/components/org/LogoUpload.tsx
@@ -30,7 +30,7 @@ export function LogoUpload({
           {logoPreview || logoImgUrl ? (
             <img
               src={logoPreview || getImageUrl(logoImgUrl)}
-              alt="회사 로고"
+              alt="회사 로고 혹은 프로필 이미지"
               className="w-full h-full object-contain bg-white rounded-full"
               style={{
                 backgroundColor: 'white',

--- a/frontend/src/components/org/OrgBasicInfo.tsx
+++ b/frontend/src/components/org/OrgBasicInfo.tsx
@@ -86,6 +86,18 @@ export function OrgBasicInfo({ formData, onInputChange, isEditing }: OrgBasicInf
       </div>
 
       <div className="space-y-2">
+        <Label htmlFor="phoneNumber" className="text-sm font-medium">
+          전화번호
+        </Label>
+        <Input
+          id="phoneNumber"
+          placeholder="전화번호를 입력하세요(ex: 010-1234-5678)"
+          value={formData.phone}
+          onChange={(e) => onInputChange('phone', e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
         <Label htmlFor="businessNumber" className="text-sm font-medium">
           사업자등록번호
         </Label>
@@ -99,25 +111,13 @@ export function OrgBasicInfo({ formData, onInputChange, isEditing }: OrgBasicInf
 
       <div className="space-y-2">
         <Label htmlFor="representative" className="text-sm font-medium">
-          대표
+          대표명
         </Label>
         <Input
           id="representative"
-          placeholder="대표자 이름을 입력하세요"
+          placeholder="대표 이름을 입력하세요"
           value={formData.representativeName}
           onChange={(e) => onInputChange('representativeName', e.target.value)}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="phoneNumber" className="text-sm font-medium">
-          전화번호
-        </Label>
-        <Input
-          id="phoneNumber"
-          placeholder="전화번호를 입력하세요(ex: 010-1234-5678)"
-          value={formData.phone}
-          onChange={(e) => onInputChange('phone', e.target.value)}
         />
       </div>
     </div>

--- a/frontend/src/components/org/OrgModal.tsx
+++ b/frontend/src/components/org/OrgModal.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 
+import { useSelector } from 'react-redux';
+
 import { OrgBaseInfo } from '@/api/org/getOrgInfo';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import { ModalComponent } from '@/components/common/ModalComponent';
 import { LogoUpload } from '@/components/org/LogoUpload';
 import { OrgBasicInfo } from '@/components/org/OrgBasicInfo';
+import { RootState } from '@/stores/store';
 import { compressAndSaveImage, validateFileSize, validateFileType } from '@/utils/file/fileStorage';
 import { showErrorToast } from '@/utils/toast';
 
@@ -42,9 +45,11 @@ export interface OrgFormData {
 
 export function OrgModal({ isOpen, onClose, onSubmit, initialInfoData }: OrgModalProps) {
   const isEditing = !!initialInfoData;
+  const memberNames = useSelector((state: RootState) => state.memberName.memberNames);
+  const currentMemberName = initialInfoData?.orgId ? memberNames[initialInfoData.orgId] || '' : '';
 
   const [formData, setFormData] = useState<OrgFormData>({
-    memberName: initialInfoData?.representativeName || '', // 임시로 대표자 이름으로 설정 추후 redux 세션스토리지에 저장한 멤버 이름(내 멤버이름)으로 변경
+    memberName: currentMemberName || '',
     logoImgUrl: initialInfoData?.logoImgUrl || '',
     name: initialInfoData?.name || '',
     address: initialInfoData?.address || '',
@@ -59,14 +64,14 @@ export function OrgModal({ isOpen, onClose, onSubmit, initialInfoData }: OrgModa
   useEffect(() => {
     if (initialInfoData) {
       setFormData({
-        memberName: initialInfoData.representativeName, // 임시로 대표자 이름으로 설정
-        logoImgUrl: initialInfoData.logoImgUrl,
+        memberName: currentMemberName || '',
+        logoImgUrl: initialInfoData.logoImgUrl || '',
         name: initialInfoData.name,
         address: initialInfoData.address,
         email: initialInfoData.email,
         businessNumber: initialInfoData.businessNumber,
         representativeName: initialInfoData.representativeName,
-        phone: initialInfoData.phone,
+        phone: initialInfoData.phone || '',
       });
     }
   }, [initialInfoData]);

--- a/frontend/src/components/project/info/ProjectInfoPage.tsx
+++ b/frontend/src/components/project/info/ProjectInfoPage.tsx
@@ -181,6 +181,7 @@ export const ProjectInfoPage = ({ projectId, orgId }: ProjectInfoPageProps) => {
           isOpen={isDeleteModalOpen}
           onClose={handleDeleteModalClose}
           title="비밀번호 확인"
+          description="프로젝트 삭제를 위해 비밀번호를 입력해주세요."
           children={
             <Input
               type="password"

--- a/frontend/src/components/project/modal/MemberSelector.tsx
+++ b/frontend/src/components/project/modal/MemberSelector.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 
 import { Search } from 'lucide-react';
 
-import { Member } from '@/api/org/getOrgMemberList';
+import { Member } from '@/types/memberTypes';
+
 import { PaginationComponent } from '@/components/common/PaginationComponent';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -51,7 +52,7 @@ export const MemberSelector = ({
     const normalizedSearchTerm = isSearchTermEnglish ? searchTerm.toLowerCase() : searchTerm;
 
     const normalizedName = normalizeText(member.name);
-    const normalizedDepartment = normalizeText(member.departmentName);
+    const normalizedDepartment = normalizeText(member.deptName);
     const normalizedPosition = normalizeText(member.positionName);
 
     return (
@@ -107,7 +108,7 @@ export const MemberSelector = ({
                     </Avatar>
                     <span className="text-sm">{member.name}</span>
                   </div>
-                  <div className="text-center text-sm text-gray-600">{member.departmentName}</div>
+                  <div className="text-center text-sm text-gray-600">{member.deptName}</div>
                   <div className="text-center text-sm text-gray-600">{member.positionName}</div>
                 </div>
               ))}

--- a/frontend/src/components/project/modal/ProjectModal.tsx
+++ b/frontend/src/components/project/modal/ProjectModal.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { Member } from '@/types/memberTypes';
 import { PROJECT_STATUS_ENG_TO_KO, PROJECT_STATUS_KO_TO_ENG } from '@/types/projectTypes';
 
-import { Member } from '@/api/org/getOrgMemberList';
 import { ProjectBaseInfo } from '@/api/project/getProjectInfo';
 import { PostCreateProjectRequest } from '@/api/project/postCreateProject';
 import { ButtonComponent } from '@/components/common/ButtonComponent';

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -13,3 +13,7 @@ export const ORG_QUERY_KEYS = {
   MY_PROJECT_LIST: 'myProjectList',
   ORG_INFO: 'orgInfo',
 } as const;
+
+export const MEMBER_QUERY_KEYS = {
+  MY_MEMBER_INFO: 'myMemberInfo',
+} as const;

--- a/frontend/src/hooks/queries/member/useMyMemberInfoQuery.ts
+++ b/frontend/src/hooks/queries/member/useMyMemberInfoQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import getMyMemberInfo from '@/api/member/getMyMemberInfo';
+import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
+
+interface UseMyMemberInfoParams {
+  orgId: number;
+  enabled?: boolean;
+}
+
+const useMyMemberInfoQuery = ({ orgId, enabled = true }: UseMyMemberInfoParams) =>
+  useQuery({
+    queryKey: [MEMBER_QUERY_KEYS.MY_MEMBER_INFO, orgId],
+    queryFn: () => getMyMemberInfo({ orgId }),
+    enabled: enabled && !!orgId,
+  });
+
+export default useMyMemberInfoQuery;

--- a/frontend/src/hooks/queries/member/useMyMemberInfoUpdateMutation.ts
+++ b/frontend/src/hooks/queries/member/useMyMemberInfoUpdateMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import putUpdateMyMemberInfo, { MemberInfoBase } from '@/api/member/putUpdateMyMemberInfo';
+import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+interface UseMyMemberInfoUpdateMutationParams {
+  orgId: number;
+}
+
+export const useMyMemberInfoUpdateMutation = ({ orgId }: UseMyMemberInfoUpdateMutationParams) =>
+  useMutation({
+    mutationFn: (request: MemberInfoBase) => putUpdateMyMemberInfo({ ...request, orgId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [MEMBER_QUERY_KEYS.MY_MEMBER_INFO, orgId],
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/member/usePasswordUpdateMutation.ts
+++ b/frontend/src/hooks/queries/member/usePasswordUpdateMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import patchPasswordChange, { PatchPasswordChangeRequest } from '@/api/member/patchPasswordChange';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+export const usePasswordUpdateMutation = () =>
+  useMutation({
+    mutationFn: (request: PatchPasswordChangeRequest) => patchPasswordChange(request),
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/member/useQuitOrgMutation.ts
+++ b/frontend/src/hooks/queries/member/useQuitOrgMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import deleteQuitOrg, { DeleteQuitOrgRequest } from '@/api/member/deleteQuitOrg';
+import { ORG_QUERY_KEYS } from '@/constants/queryKeys';
+import { queryClient } from '@/main';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+export const useQuitOrgMutation = () =>
+  useMutation({
+    mutationFn: (request: DeleteQuitOrgRequest) => deleteQuitOrg(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ORG_QUERY_KEYS.MY_ORG_LIST],
+        exact: false,
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/hooks/queries/user/useUserDeleteMutation.ts
+++ b/frontend/src/hooks/queries/user/useUserDeleteMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { AxiosError } from 'axios';
+
+import deleteUser, { DeleteUserRequest } from '@/api/user/deleteUser';
+import { handleHttpError, logError } from '@/utils/auth/errorUtils';
+
+export const useUserDeleteMutation = () =>
+  useMutation({
+    mutationFn: (request: DeleteUserRequest) => deleteUser(request),
+    onError: (error: AxiosError) => {
+      logError(error);
+      handleHttpError(error);
+    },
+  });

--- a/frontend/src/routes/info/$orgId/index.tsx
+++ b/frontend/src/routes/info/$orgId/index.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+
+import { createFileRoute, useParams } from '@tanstack/react-router';
+
+import { MyMemberInfoDetail } from '@/api/member/getMyMemberInfo';
+import { MemberInfoBase } from '@/api/member/putUpdateMyMemberInfo';
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { MemberInfoForm } from '@/components/member/MemberInfoForm';
+import { LogoUpload } from '@/components/org/LogoUpload';
+import useMyMemberInfoQuery from '@/hooks/queries/member/useMyMemberInfoQuery';
+import { useMyMemberInfoUpdateMutation } from '@/hooks/queries/member/useMyMemberInfoUpdateMutation';
+import { compressAndSaveImage, validateFileSize, validateFileType } from '@/utils/file/fileStorage';
+import { showErrorToast, showSuccessToast } from '@/utils/toast';
+
+export const Route = createFileRoute('/info/$orgId/')({
+  component: MemberInfoPage,
+});
+
+function MemberInfoPage() {
+  const params = useParams({ strict: false });
+  const orgId = params.orgId;
+
+  const { data: myMemberInfoData } = useMyMemberInfoQuery({ orgId: Number(orgId) });
+
+  const { mutate: updateMyMemberInfo } = useMyMemberInfoUpdateMutation({
+    orgId: Number(orgId),
+  });
+
+  const myMemberInfo = myMemberInfoData as unknown as MyMemberInfoDetail;
+
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (myMemberInfo) {
+      setFormData({
+        name: myMemberInfo.name,
+        email: myMemberInfo.email,
+        profileImgUrl: myMemberInfo.profileImgUrl,
+        deptName: myMemberInfo.deptName,
+        positionName: myMemberInfo.positionName,
+        phone: myMemberInfo.phone === '' ? null : myMemberInfo.phone,
+      });
+    }
+  }, [myMemberInfo]);
+
+  const [formData, setFormData] = useState<MemberInfoBase>({
+    name: '',
+    email: '',
+    profileImgUrl: '',
+    deptName: '',
+    positionName: '',
+    phone: '',
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      updateMyMemberInfo(formData);
+      showSuccessToast('정보가 저장되었습니다.');
+    } catch (error) {
+      // 에러 토스트
+      // showErrorToast('정보 저장 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleLogoUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setLogoPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleFileSelect = async (file: File) => {
+    try {
+      // 파일 검증
+      if (!validateFileType(file)) {
+        showErrorToast('지원하지 않는 파일 형식입니다. (JPG, PNG, GIF만 가능)');
+        return;
+      }
+
+      if (!validateFileSize(file, 5)) {
+        showErrorToast('파일 크기는 5MB 이하여야 합니다.');
+        return;
+      }
+
+      // 미리보기를 위한 이미지 압축 및 저장(메모리에 임시 저장)
+      const compressedImageUrl = await compressAndSaveImage(file, 800, 0.8);
+      setLogoPreview(compressedImageUrl);
+      setFormData((prev) => ({
+        ...prev,
+        profileImgUrl: compressedImageUrl,
+      }));
+    } catch (error) {
+      showErrorToast('이미지 처리 중 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-6 justify-center items-center mt-20"
+      >
+        <LogoUpload
+          logoImgUrl={formData.profileImgUrl ?? ''}
+          logoPreview={logoPreview ?? ''}
+          onLogoUpload={handleLogoUpload}
+          onFileSelect={handleFileSelect}
+        />
+
+        <MemberInfoForm formData={formData} onInputChange={handleInputChange} />
+
+        {/* <DepartmentPositionManager
+    departments={formData.departments}
+    positions={formData.positions}
+    onDepartmentsChange={(departments) =>
+      setFormData((prev) => ({ ...prev, departments }))
+    }
+    onPositionsChange={(positions) => setFormData((prev) => ({ ...prev, positions }))}
+    /> */}
+        <ButtonComponent className="w-full max-w-lg" type="submit">
+          저장
+        </ButtonComponent>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/routes/info/password.tsx
+++ b/frontend/src/routes/info/password.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { PasswordChangeForm } from '@/components/member/PasswordChangeForm';
+import { usePasswordUpdateMutation } from '@/hooks/queries/member/usePasswordUpdateMutation';
+import { showSuccessToast } from '@/utils/toast';
+
+export const Route = createFileRoute('/info/password')({
+  component: PasswordPage,
+});
+
+function PasswordPage() {
+  const { mutate: updatePassword } = usePasswordUpdateMutation();
+
+  const [formData, setFormData] = useState<{
+    currentPassword: string;
+    newPassword: string;
+    newPasswordCheck: string;
+  }>({
+    currentPassword: '',
+    newPassword: '',
+    newPasswordCheck: '',
+  });
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = () => {
+    try {
+      updatePassword({
+        currentPassword: formData.currentPassword,
+        newPassword: formData.newPassword,
+        newPasswordCheck: formData.newPasswordCheck,
+      });
+      showSuccessToast('비밀번호가 변경되었습니다.');
+    } catch (error) {
+      // 에러 토스트
+      // showErrorToast('비밀번호 변경 중 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 justify-center items-center mt-20 p-20">
+      <PasswordChangeForm formData={formData} onInputChange={handleInputChange} />
+      <ButtonComponent onClick={handleSubmit} className="w-full max-w-lg" type="submit">
+        비밀번호 변경
+      </ButtonComponent>
+    </div>
+  );
+}

--- a/frontend/src/routes/info/route.tsx
+++ b/frontend/src/routes/info/route.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+import { SettingSidebarComponent } from '@/components/common/left-sidebar/SettingSidebarComponent';
+import { NavigationMenuComponent } from '@/components/common/navigation-menu/NavigationMenuComponent';
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
+
+export const Route = createFileRoute('/info')({
+  component: InfoLayoutComponent,
+});
+
+function InfoLayoutComponent() {
+  return (
+    <div>
+      <NavigationMenuComponent isInfoPage={true} />
+      <SidebarProvider>
+        <SettingSidebarComponent />
+        <SidebarInset className="pt-16">
+          <Outlet />
+        </SidebarInset>
+      </SidebarProvider>
+    </div>
+  );
+}

--- a/frontend/src/routes/info/withdraw.tsx
+++ b/frontend/src/routes/info/withdraw.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { ButtonComponent } from '@/components/common/ButtonComponent';
+import { WithdrawConfirmModal } from '@/components/member/WithdrawConfirmModal';
+import { useUserDeleteMutation } from '@/hooks/queries/user/useUserDeleteMutation';
+import { logout } from '@/stores/authSlice';
+import { useAppDispatch } from '@/stores/hooks';
+import { getEmailFromToken } from '@/utils/auth/tokenUtils';
+import { showSuccessToast } from '@/utils/toast';
+
+export const Route = createFileRoute('/info/withdraw')({
+  component: WithdrawPage,
+});
+
+function WithdrawPage() {
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+
+  const dispatch = useAppDispatch();
+
+  const { mutate: withdraw, isPending } = useUserDeleteMutation();
+
+  const userEmail = getEmailFromToken() || 'example@example.com';
+
+  const handleWithdrawClick = () => {
+    setIsConfirmModalOpen(true);
+  };
+
+  const handleConfirmWithdraw = (currentPassword: string) => {
+    withdraw(
+      { password: currentPassword },
+      {
+        onSuccess: () => {
+          dispatch(logout());
+          showSuccessToast('계정이 성공적으로 탈퇴되었습니다.');
+          window.location.href = '/';
+        },
+        onError: () => {
+          // 에러 토스트
+          // showErrorToast('계정 탈퇴에 실패했습니다.');
+        },
+      },
+    );
+  };
+
+  const handleCloseModal = () => {
+    setIsConfirmModalOpen(false);
+  };
+
+  return (
+    <div className="bg-white p-6">
+      <div className="max-w-2xl mx-auto space-y-8">
+        <div className="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
+          <span className="text-sm font-medium text-gray-700">탈퇴할 계정</span>
+          <span className="text-sm text-gray-900">{userEmail}</span>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">탈퇴 시 주의사항</h2>
+          <div className="bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
+            <div className="space-y-4 text-sm text-gray-700 leading-relaxed">
+              <div className="flex items-start space-x-3">
+                <span className="font-medium text-gray-900">1.</span>
+                <p>
+                  계정 탈퇴 시 기존에 작성하신 모든 기록(사용자 정보, 게시글, 댓글 등)은 완전히
+                  삭제되지 않고 익명화 처리됩니다. 이는 서비스의 연속성과 다른 사용자들의 경험을
+                  보호하기 위한 조치입니다.
+                </p>
+              </div>
+              <div className="flex items-start space-x-3">
+                <span className="font-medium text-gray-900">2.</span>
+                <p>
+                  탈퇴하려는 계정이 특정 조직에서 마지막 루트 관리자인 경우, 다른 구성원에게 루트
+                  관리자 권한을 위임한 후 탈퇴가 가능합니다. 이는 조직의 안정적인 운영을 위한 필수
+                  절차입니다.
+                </p>
+              </div>
+              <div className="flex items-start space-x-3">
+                <span className="font-medium text-gray-900">3.</span>
+                <p>
+                  계정 탈퇴는 되돌릴 수 없는 작업입니다. 탈퇴 후에는 모든 서비스 이용이 중단되며,
+                  기존 데이터에 대한 접근이 제한됩니다.
+                </p>
+              </div>
+              <div className="flex items-start space-x-3">
+                <span className="font-medium text-gray-900">4.</span>
+                <p>
+                  탈퇴 처리에는 최대 24시간이 소요될 수 있으며, 이 기간 동안 일부 서비스 이용이
+                  제한될 수 있습니다.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="pt-6">
+          <ButtonComponent
+            variant="danger"
+            onClick={handleWithdrawClick}
+            className="w-full py-4 text-md font-medium bg-red-500 hover:bg-red-600 text-white"
+            disabled={isPending}
+          >
+            {isPending ? '처리 중...' : '탈퇴하기'}
+          </ButtonComponent>
+        </div>
+      </div>
+
+      {isConfirmModalOpen && (
+        <WithdrawConfirmModal
+          isOpen={isConfirmModalOpen}
+          onClose={handleCloseModal}
+          onConfirm={handleConfirmWithdraw}
+          isLoading={isPending}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/org/$orgId/info/index.tsx
+++ b/frontend/src/routes/org/$orgId/info/index.tsx
@@ -221,15 +221,15 @@ function OrgInfoPage() {
             </div>
 
             <div className="flex flex-col gap-2">
-              <div className="text-gray-600 font-bold">주소</div>
-              <p className="text-gray-600 text-sm">{orgInfo?.address}</p>
               <div className="text-gray-600 font-bold">이메일</div>
               <p className="text-gray-600 text-sm">{orgInfo?.email}</p>
+              <div className="text-gray-600 font-bold">주소</div>
+              <p className="text-gray-600 text-sm">{orgInfo?.address}</p>
               <div className="text-gray-600 font-bold">전화번호</div>
               <p className="text-gray-600 text-sm">{orgInfo?.phone}</p>
-              <div className="text-gray-600 font-bold">사업자번호</div>
+              <div className="text-gray-600 font-bold">사업자 등록번호</div>
               <p className="text-gray-600 text-sm">{orgInfo?.businessNumber}</p>
-              <div className="text-gray-600 font-bold">대표자</div>
+              <div className="text-gray-600 font-bold">대표명</div>
               <p className="text-gray-600 text-sm">{orgInfo?.representativeName}</p>
             </div>
           </div>

--- a/frontend/src/routes/org/$orgId/info/index.tsx
+++ b/frontend/src/routes/org/$orgId/info/index.tsx
@@ -90,9 +90,9 @@ function OrgInfoPage() {
         address: data.address || '',
         email: data.email || '',
         representativeName: data.representativeName || '',
-        phone: data.phone || '',
+        phone: data.phone === '' ? null : data.phone || '',
         businessNumber: data.businessNumber || '',
-        logoImgUrl: data.logoImgUrl || '',
+        logoImgUrl: data.logoImgUrl === '' ? null : data.logoImgUrl || '',
       });
       showSuccessToast(TOAST_MESSAGES.CRUD.UPDATE_SUCCESS);
       handleEditModalClose();

--- a/frontend/src/stores/memberSlice.ts
+++ b/frontend/src/stores/memberSlice.ts
@@ -1,0 +1,57 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface MemberState {
+  memberNames: Record<number, string>;
+}
+
+const getInitialMemberNames = (): Record<number, string> => {
+  try {
+    const stored = sessionStorage.getItem('memberNames');
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+};
+
+const initialState: MemberState = {
+  memberNames: getInitialMemberNames(),
+};
+
+const memberSlice = createSlice({
+  name: 'memberName',
+  initialState,
+  reducers: {
+    setMemberName: (state, action: PayloadAction<{ orgId: number; memberName: string }>) => {
+      const { orgId, memberName } = action.payload;
+      state.memberNames[orgId] = memberName;
+      try {
+        sessionStorage.setItem('memberNames', JSON.stringify(state.memberNames));
+      } catch (error) {
+        console.warn('Failed to save member name to sessionStorage:', error);
+      }
+    },
+
+    clearMemberName: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      delete state.memberNames[orgId];
+      try {
+        sessionStorage.setItem('memberNames', JSON.stringify(state.memberNames));
+      } catch (error) {
+        console.warn('Failed to remove member name from sessionStorage:', error);
+      }
+    },
+
+    clearAllMemberNames: (state) => {
+      state.memberNames = {};
+      try {
+        sessionStorage.removeItem('memberNames');
+      } catch (error) {
+        console.warn('Failed to remove all member names from sessionStorage:', error);
+      }
+    },
+  },
+});
+
+export const { setMemberName, clearMemberName, clearAllMemberNames } = memberSlice.actions;
+
+export default memberSlice.reducer;

--- a/frontend/src/stores/store.ts
+++ b/frontend/src/stores/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import authReducer from '@/stores/authSlice';
+import memberReducer from '@/stores/memberSlice';
 import projectReducer from '@/stores/projectSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    memberName: memberReducer,
     projectName: projectReducer,
   },
   middleware: (getDefaultMiddleware) =>

--- a/frontend/src/utils/auth/tokenUtils.ts
+++ b/frontend/src/utils/auth/tokenUtils.ts
@@ -65,3 +65,20 @@ export const getMemberIdFromToken = (): number => {
     return 0;
   }
 };
+
+export const getEmailFromToken = (): string | null => {
+  const token = getAccessTokenFromStore();
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const base64Payload = token.split('.')[1];
+    const payload = JSON.parse(atob(base64Payload));
+
+    return payload?.email || null;
+  } catch (error) {
+    console.error('토큰에서 이메일 추출 중 오류 발생:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
## 📌 제목
feat(fe/be): 개인정보 페이지 ui 구현 및 api 연동

----------------------------------------

## 🔗 관련 이슈

## ✅ 작업 내용
- 회사 내 개인정보 관리 페이지 전체 ui 구현
- 회사 내 개인정보 조회 api 연동
- 회사 내 개인정보 수정 api 연동
- 비밀번호 변경 api 연동
- 계정 탈퇴 api 연동
- 회사 나가기 api 연동


## 📝 기타 참고 사항
- 테스트 방법, 추가로 공유할 내용

