### PR TITLE
feat(fe): 게시판 수정, 삭제 모달 추가 및 관련 코드 일부 수정

### DIFF
--- a/frontend/src/api/board/boardApi.ts
+++ b/frontend/src/api/board/boardApi.ts
@@ -7,7 +7,7 @@ export interface BoardCreatePayload {
 }
 
 export interface BoardUpdatePayload {
-  boardId: number;
+  name: string;
 }
 
 export const getBoardList = async (orgId: number) => {

--- a/frontend/src/components/board/BoardModal.tsx
+++ b/frontend/src/components/board/BoardModal.tsx
@@ -1,0 +1,66 @@
+import { useState, type ReactNode } from 'react';
+
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+
+import { ButtonComponent } from '../common/ButtonComponent';
+
+interface Props {
+  triggerButton: ReactNode;
+  title: string;
+  description: ReactNode;
+  children?: ReactNode; // 별도로 들어갈 내용
+  cancelButtonText?: string;
+  confirmButtonText: string;
+  onConfirm: () => void; // 확인 버튼을 눌렀을 때 실행될 함수
+}
+
+export const BoardModal = ({
+  triggerButton,
+  title,
+  description,
+  children,
+  cancelButtonText = '취소',
+  confirmButtonText,
+  onConfirm,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onConfirm();
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>{triggerButton}</DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          {/* 별도로 추가할 내용 */}
+          {children}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <ButtonComponent variant="danger">{cancelButtonText}</ButtonComponent>
+            </DialogClose>
+            <ButtonComponent type="submit">{confirmButtonText}</ButtonComponent>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/board/DeleteBoardModal.tsx
+++ b/frontend/src/components/board/DeleteBoardModal.tsx
@@ -1,0 +1,27 @@
+import { useBoardDeleteMutation } from '@/hooks/queries/board/useBoardDeleteMutation';
+
+import { BoardModal } from './BoardModal';
+import { ButtonComponent } from '../common/ButtonComponent';
+
+interface Props {
+  orgId: number;
+  boardId: number;
+}
+
+export const DeleteBoardModal = ({ orgId, boardId }: Props) => {
+  const { mutate: deleteBoard } = useBoardDeleteMutation(orgId, boardId);
+
+  const handleConfirm = () => {
+    deleteBoard();
+  };
+
+  return (
+    <BoardModal
+      triggerButton={<ButtonComponent variant="danger">게시판 삭제</ButtonComponent>}
+      title="게시판을 삭제하시겠습니까?"
+      description="해당 게시판의 모든 데이터가 삭제되며, 이 작업은 되돌릴 수 없습니다."
+      confirmButtonText="삭제"
+      onConfirm={handleConfirm}
+    />
+  );
+};

--- a/frontend/src/components/board/NewBoardModal.tsx
+++ b/frontend/src/components/board/NewBoardModal.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react';
 
-import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogClose,
-} from '@/components/ui/dialog';
 import { useBoardCreateMutation } from '@/hooks/queries/board/useBoardCreateMutation';
 
+import { BoardModal } from './BoardModal';
 import { ButtonComponent } from '../common/ButtonComponent';
 import { Input } from '../ui/input';
 
@@ -21,53 +12,28 @@ interface Props {
 
 export const NewBoardModal = ({ orgId }: Props) => {
   const { mutate: createBoard } = useBoardCreateMutation(orgId);
-  const [isOpen, setIsOpen] = useState(false);
   const [inputName, setInputName] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const savedName = inputName.trim();
-
+  const handleConfirm = () => {
     createBoard(
-      { name: savedName },
+      { name: inputName.trim() },
       {
-        onSuccess: () => {
-          setIsOpen(false);
-          setInputName('');
-        },
+        onSuccess: () => setInputName(''),
       },
     );
   };
+
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild>
-        <ButtonComponent>+ 게시판 추가</ButtonComponent>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
-        <form onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>새 게시판 만들기</DialogTitle>
-            <DialogDescription>
-              새로운 게시판을 만들어 다양한 주제의 게시글을 작성해보세요!
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="grid gap-4 py-4">
-            <Input name={inputName} onChange={(e) => setInputName(e.target.value)} />
-          </div>
-
-          <DialogFooter>
-            <DialogClose>
-              {' '}
-              <ButtonComponent variant="danger" onCanPlay={() => setIsOpen(false)}>
-                취소
-              </ButtonComponent>
-            </DialogClose>
-            <ButtonComponent type="submit">만들기</ButtonComponent>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <BoardModal
+      triggerButton={<ButtonComponent>+ 게시판 추가</ButtonComponent>}
+      title="새 게시판 만들기"
+      description="새로운 게시판을 만들어 다양한 주제의 게시글을 작성해보세요!"
+      confirmButtonText="만들기"
+      onConfirm={handleConfirm}
+    >
+      <div className="grid gap-4 py-4">
+        <Input value={inputName} onChange={(e) => setInputName(e.target.value)} />
+      </div>
+    </BoardModal>
   );
 };

--- a/frontend/src/components/board/UpdateBoardModal.tsx
+++ b/frontend/src/components/board/UpdateBoardModal.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+import { useBoardUpdateMutation } from '@/hooks/queries/board/useBoardUpdateMutation';
+
+import { BoardModal } from './BoardModal';
+import { ButtonComponent } from '../common/ButtonComponent';
+import { Input } from '../ui/input';
+
+interface Props {
+  orgId: number;
+  boardId: number;
+}
+
+export const UpdateBoardModal = ({ orgId, boardId }: Props) => {
+  const { mutate: updateBoard } = useBoardUpdateMutation(orgId, boardId);
+  const [inputName, setInputName] = useState('');
+
+  const handleConfirm = () => {
+    updateBoard(inputName.trim(), {
+      onSuccess: () => setInputName(''),
+    });
+  };
+
+  return (
+    <BoardModal
+      triggerButton={<ButtonComponent>게시판 이름 수정</ButtonComponent>}
+      title="게시판 이름 수정"
+      description="새로운 게시판 이름을 입력해주세요"
+      confirmButtonText="수정하기"
+      onConfirm={handleConfirm}
+    >
+      <div className="grid gap-4 py-4">
+        <Input value={inputName} onChange={(e) => setInputName(e.target.value)} />
+      </div>
+    </BoardModal>
+  );
+};

--- a/frontend/src/components/common/left-sidebar/AppSidebarComponent.tsx
+++ b/frontend/src/components/common/left-sidebar/AppSidebarComponent.tsx
@@ -60,7 +60,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         icon: ClipboardList,
         items: myBoardList?.map((board) => ({
           title: board.name,
-          url: `/org/${currentOrgId}/boards/${board.boardId}/posts`,
+          url: `/org/${currentOrgId}/boards/${board.boardId === 0 ? 'all' : board.boardId}/posts`,
         })),
       },
       {

--- a/frontend/src/hooks/queries/board/useBoardDeleteMutation.ts
+++ b/frontend/src/hooks/queries/board/useBoardDeleteMutation.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteBoard } from '@/api/board/boardApi';
 import { showToast } from '@/utils/toast';
 
-export const useBoardCreateMutation = (orgId: number, boardId: number) => {
+export const useBoardDeleteMutation = (orgId: number, boardId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/frontend/src/hooks/queries/board/useBoardUpdateMutation.ts
+++ b/frontend/src/hooks/queries/board/useBoardUpdateMutation.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { BoardUpdatePayload, updateBoard } from '@/api/board/boardApi';
+import { updateBoard } from '@/api/board/boardApi';
 import { showToast } from '@/utils/toast';
 
-export const useBoardCreateMutation = (orgId: number, boardId: number) => {
+export const useBoardUpdateMutation = (orgId: number, boardId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (payload: BoardUpdatePayload) => updateBoard(orgId, boardId, payload),
+    mutationFn: (name: string) => updateBoard(orgId, boardId, { name }),
 
     onSuccess: () => {
       showToast('success', '게시판 수정에 성공하였습니다.');

--- a/frontend/src/pages/board/BoardListPage.tsx
+++ b/frontend/src/pages/board/BoardListPage.tsx
@@ -18,9 +18,6 @@ export const BoardListPage = ({ orgId, boardList }: Props) => (
         </div>
         <div className="flex gap-2">
           <NewBoardModal orgId={orgId} />
-          {/* <ButtonComponent variant="danger" size="sm" onClick={() => {}}>
-            <Plus size={16} />새 게시판 등록
-          </ButtonComponent> */}
         </div>
       </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #142 

## ✅ 작업 내용
- 게시판 관련 모달을 `BoardModal`로 공통부분 분리하였습니다.
- `DeleteBoardModal`, `UpdateBoardModal`로 삭제, 수정 모달을 사용할 수 있습니다.
- 관련된 Hook의 오탈자를 수정하였습니다.
- 사이드바의 전체 글 보기 경로를 수정하였습니다.

## 📝 기타 참고 사항
- x

