### PR TITLE
feat(fe/be): 이메일 인증 관련 프론트 및 백엔드 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/controller/AuthController.java
@@ -6,14 +6,17 @@ import com.ourhour.domain.auth.service.AuthService;
 import com.ourhour.global.common.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +28,15 @@ public class AuthController {
 
     @Value("${jwt.refresh-token-validity-in-seconds}")
     private long refreshTokenValidityInSeconds;
+
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponse<Boolean>> checkAvailEmail(@Email @RequestParam String email) {
+        boolean isAvailable = authService.checkAvailEmail(email);
+
+        ApiResponse<Boolean> response = ApiResponse.success(isAvailable, isAvailable ? "사용 가능한 이메일입니다." : "이미 사용중인 이메일입니다.");
+
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody SignupReqDTO signupReqDTO) {
@@ -72,7 +84,6 @@ public class AuthController {
     @PostMapping("/signout")
     public ResponseEntity<ApiResponse<Void>> signout(HttpServletResponse response) {
 
-        System.out.println("잉??왜 안됨??");
         authService.signout();
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")

--- a/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/service/AuthService.java
@@ -38,14 +38,27 @@ public class AuthService {
     private final JwtClaimMapper jwtClaimMapper;
     private final PasswordEncoder passwordEncoder;
 
+    // 이메일 중복 확인
+    @Transactional(readOnly = true)
+    public boolean checkAvailEmail (String email) {
+
+        boolean alreadyHasEmail = userRepository.existsByEmailAndIsDeletedFalse(email);
+        if (alreadyHasEmail) {
+            return false;
+        }
+
+        return true;
+
+    }
+
     // 회원가입
     @Transactional
     public void signup(SignupReqDTO signupReqDTO) {
 
         // 이메일 중복 및 탈퇴된 이메일이 아닌지 확인
-        if (userRepository.existsByEmailAndIsDeletedFalse(signupReqDTO.getEmail())) {
+        if (!checkAvailEmail(signupReqDTO.getEmail())) {
             throw duplicateRequestException();
-        }
+        };
 
         boolean isVerified = emailVerificationRepository.existsByEmailAndIsUsedTrue(signupReqDTO.getEmail());
         if(!isVerified) {

--- a/backend/src/main/java/com/ourhour/domain/auth/service/EmailVerificationService.java
+++ b/backend/src/main/java/com/ourhour/domain/auth/service/EmailVerificationService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.*;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -15,7 +14,7 @@ public class EmailVerificationService extends AbstractVerificationService<EmailV
 
     private final EmailVerificationRepository emailVerificationRepository;
 
-    @Value("${spring.service.base-url-email}")
+    @Value("${spring.service.url.front}")
     private String serviceBaseUrl;
 
     public EmailVerificationService(EmailSenderService emailSenderService, EmailVerificationRepository emailVerificationRepository) {
@@ -34,7 +33,7 @@ public class EmailVerificationService extends AbstractVerificationService<EmailV
         String token = sendVerificationEmail(
                 email,
                 serviceBaseUrl,
-                "/api/auth/email-verification?token=",
+                "/auth/email-verification?token=",
                 subject,
                 contentTemplate,
                 linkName);

--- a/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private static final Set<String> EXCLUDE_URI_PREFIXES = Set.of(
+            "/api/auth/check-email",
             "/api/auth/signup",
             "/api/auth/signin",
             "/api/auth/email-verification",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,12 +9,12 @@
     <link rel="icon" type="image/png" sizes="192x192" href="/favicon/android-chrome-192x192.png" />
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon/android-chrome-512x512.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <!-- <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Nanum+Barun+Gothic:wght@400;700&display=swap"
       rel="stylesheet"
-    />
+    /> -->
     <title>ourhour</title>
   </head>
   <body>

--- a/frontend/src/api/auth/getCheckEmail.ts
+++ b/frontend/src/api/auth/getCheckEmail.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from 'axios';
+
+import { ApiResponse } from '@/types/apiTypes';
+
+import { axiosInstance } from '@/api/axiosConfig';
+import { logError } from '@/utils/auth/errorUtils';
+
+export interface CheckDupEmailRequest {
+  email: string;
+}
+
+/*
+ * 이메일 중복 확인 (true = 사용 가능, false = 이미 사용 중)
+ */
+const getCheckEmail = async (request: CheckDupEmailRequest): Promise<ApiResponse<boolean>> => {
+  try {
+    const response = await axiosInstance.get('/api/auth/check-email', {
+      params: { email: request.email },
+    });
+
+    return response.data;
+  } catch (error) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+export default getCheckEmail;

--- a/frontend/src/api/auth/getEmailVerification.ts
+++ b/frontend/src/api/auth/getEmailVerification.ts
@@ -1,0 +1,56 @@
+import { AxiosError } from 'axios';
+
+import type { ApiResponse } from '@/types/apiTypes';
+
+import axiosInstance from '@/api/axiosConfig';
+
+export interface GetEmailVerificationRequest {
+  token: string;
+}
+
+export type FailReason = 'expired' | 'invalid' | 'already' | 'server';
+
+export type EmailVerificationResult =
+  | { ok: true; status: number; message: string }
+  | { ok: false; status: number; reason: FailReason; message: string };
+
+function mapErrorToReason(err: AxiosError<ApiResponse<void>>): FailReason {
+  const status = err.response?.status;
+  const msg = err.response?.data?.message ?? '';
+
+  if (/만료/i.test(msg)) {
+    return 'expired';
+  }
+  if (status === 400 || /유효하지/i.test(msg)) {
+    return 'invalid';
+  }
+  if (/이미 인증/i.test(msg)) {
+    return 'already';
+  }
+  return 'server';
+}
+
+export async function getEmailVerification({
+  token,
+}: GetEmailVerificationRequest): Promise<EmailVerificationResult> {
+  try {
+    const resp = await axiosInstance.get<ApiResponse<void>>('/api/auth/email-verification', {
+      params: { token },
+      headers: { skipAuth: 'true', skipRefresh: 'true' },
+    });
+
+    const api = resp.data as ApiResponse<void> | undefined;
+    const message = api?.message ?? '이메일 인증에 성공했습니다.';
+    const status = resp.status;
+
+    return { ok: true, status, message };
+  } catch (error) {
+    const err = error as AxiosError<ApiResponse<void>>;
+    const api = err.response?.data;
+    const status = err.response?.status ?? 500;
+    const message = api?.message ?? '이메일 인증에 실패했습니다.';
+    const reason = mapErrorToReason(err);
+
+    return { ok: false, status, reason, message };
+  }
+}

--- a/frontend/src/components/auth/EmailVerification.tsx
+++ b/frontend/src/components/auth/EmailVerification.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+
+import { useRouter } from '@tanstack/react-router';
+
+import { getEmailVerification } from '@/api/auth/getEmailVerification';
+import postSignup from '@/api/auth/postSignup';
+import { Route as emailVerifyRoute } from '@/routes/auth/email-verification';
+import { getPendingSignup, clearPendingSignup } from '@/utils/auth/pendingSignupStorage';
+import { showSuccessToast, TOAST_MESSAGES } from '@/utils/toast';
+
+export function EmailVerification() {
+  const router = useRouter();
+  const { token } = emailVerifyRoute.useSearch();
+  const hasRunEffect = useRef(false); // useRef를 사용하여 이펙트 내부의 비동기 로직이 한 번만 실행되도록 제어
+
+  useEffect(() => {
+    if (hasRunEffect.current) {
+      return;
+    }
+    hasRunEffect.current = true;
+
+    if (!token) {
+      router.navigate({
+        to: '/auth/fail',
+        search: { reason: 'invalid' },
+        replace: true,
+      });
+      return;
+    }
+
+    const cancelled = false;
+
+    const run = async () => {
+      // 이메일 토큰 검증
+      const verifyResult = await getEmailVerification({ token });
+
+      if (cancelled) {
+        return;
+      }
+
+      // 이메일 인증 실패 시 인증 실패 화면으로 이동
+      if (!(verifyResult.ok && verifyResult.status === 200)) {
+        router.navigate({
+          to: '/auth/fail',
+          search: { reason: !verifyResult.ok ? verifyResult.reason : 'server' },
+          replace: true,
+        });
+        return;
+      }
+
+      // session storage에 저장된 이메일, 비밀번호 가져오기
+      const pending = getPendingSignup();
+
+      if (pending) {
+        try {
+          await postSignup(pending); // 회원가입
+
+          showSuccessToast(TOAST_MESSAGES.AUTH.SIGNUP_SUCCESS);
+
+          // 인증 완료 시 즉시 삭제
+          clearPendingSignup();
+        } catch {
+          /* empty */
+        }
+      }
+
+      showSuccessToast(TOAST_MESSAGES.AUTH.EMAIL_VERIFICATION);
+
+      setTimeout(() => {
+        router.navigate({
+          to: '/login',
+          search: { verified: 'success' },
+          replace: true,
+        });
+      }, 1500);
+    };
+
+    void run();
+  }, [token, router]);
+
+  return <div>이메일 인증 중...</div>;
+}

--- a/frontend/src/components/auth/EmailVerificationFail.tsx
+++ b/frontend/src/components/auth/EmailVerificationFail.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import { useRouter } from '@tanstack/react-router';
+
+import { ModalComponent } from '@/components/common/ModalComponent';
+import { Route as FailRoute } from '@/routes/auth/fail';
+
+type FailReason = 'expired' | 'invalid' | 'server' | (string & {});
+
+interface ReasonContent {
+  title: string;
+  description: string;
+  primaryActionLabel: string;
+  secondaryActionLabel?: string;
+  showResend?: boolean;
+}
+
+function getReasonContent(reason?: string): ReasonContent {
+  switch (reason as FailReason) {
+    case 'expired':
+      return {
+        title: '인증 링크 만료',
+        description:
+          '이메일 인증 링크가 만료되었습니다. 새로 가입하거나 인증 메일을 다시 받아주세요.',
+        primaryActionLabel: '회원가입으로 이동',
+      };
+    case 'invalid':
+      return {
+        title: '잘못된 링크',
+        description: '링크가 올바르지 않습니다. 다시 시도해주세요.',
+        primaryActionLabel: '회원가입으로 이동',
+      };
+    case 'server':
+      return {
+        title: '이메일 인증 실패',
+        description: '인증에 실패했습니다. 다시 시도하거나 새로 가입해주세요.',
+        primaryActionLabel: '회원가입으로 이동',
+      };
+    default:
+      return {
+        title: '이메일 인증 실패',
+        description: '인증에 실패했습니다. 다시 시도하거나 새로 가입해주세요.',
+        primaryActionLabel: '회원가입으로 이동',
+      };
+  }
+}
+
+export function EmailVerificationFail() {
+  const router = useRouter();
+  const { reason } = FailRoute.useSearch();
+
+  const [isOpen] = React.useState(true);
+
+  const content = getReasonContent(reason);
+
+  const goSignup = () => {
+    router.navigate({
+      to: '/signup',
+    });
+  };
+
+  return (
+    <ModalComponent
+      isOpen={isOpen}
+      onClose={goSignup}
+      title={content.title}
+      description={content.description}
+      footer={
+        <div className="flex justify-center gap-4">
+          <button
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            onClick={goSignup}
+          >
+            {content.primaryActionLabel}
+          </button>
+        </div>
+      }
+    >
+      <div className="text-center text-gray-600">
+        <p>{content.description}</p>
+      </div>
+    </ModalComponent>
+  );
+}

--- a/frontend/src/components/auth/SignupForm.tsx
+++ b/frontend/src/components/auth/SignupForm.tsx
@@ -4,6 +4,7 @@ import getCheckEmail from '@/api/auth/getCheckEmail';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { Input } from '@/components/ui/input';
+import { setPendingSignup } from '@/utils/auth/pendingSignupStorage';
 import { validateEmail, validatePassword } from '@/utils/validation/authValidation';
 
 interface SignupFormProps {
@@ -64,14 +65,15 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
     try {
       const isAvailable = await getCheckEmail({ email });
 
-      if (!isAvailable) {
-        console.log(isAvailable);
+      if (!isAvailable.data) {
         setEmailError('이미 사용중인 이메일입니다.');
         return;
       }
     } catch (error) {
       setEmailError('이메일 확인 중 오류가 발생했습니다.');
     }
+
+    setPendingSignup({ email, password }); // 아이디, 비밀번호 임시저장
 
     onSubmit(email, password);
   };

--- a/frontend/src/components/auth/SignupForm.tsx
+++ b/frontend/src/components/auth/SignupForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import getCheckEmail from '@/api/auth/getCheckEmail';
 import { ButtonComponent } from '@/components/common/ButtonComponent';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { Input } from '@/components/ui/input';
@@ -40,7 +41,7 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
   };
 
   // 이메일 인증 버튼 클릭 시
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     const emailValidation = validateEmail(email);
@@ -57,6 +58,19 @@ const SignupForm = ({ onSubmit, isLoading }: SignupFormProps) => {
 
     if (!emailValidation.isValid || !passwordValidation.isValid || passwordConfirm !== password) {
       return;
+    }
+
+    // 이메일 중복 확인
+    try {
+      const isAvailable = await getCheckEmail({ email });
+
+      if (!isAvailable) {
+        console.log(isAvailable);
+        setEmailError('이미 사용중인 이메일입니다.');
+        return;
+      }
+    } catch (error) {
+      setEmailError('이메일 확인 중 오류가 발생했습니다.');
     }
 
     onSubmit(email, password);

--- a/frontend/src/components/landing/Header.tsx
+++ b/frontend/src/components/landing/Header.tsx
@@ -35,18 +35,18 @@ export const Header = () => {
   };
 
   // 토큰 검증이 완료될 때까지 로딩 상태 표시
-  if (isLoading) {
-    return (
-      <header className="border-b border-gray-200/50 bg-white/80 backdrop-blur-sm">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <div className="w-20 h-8 bg-gray-200 rounded animate-pulse" />
-            <div className="w-24 h-8 bg-gray-200 rounded animate-pulse" />
-          </div>
-        </div>
-      </header>
-    );
-  }
+  // if (isLoading) {
+  //   return (
+  //     <header className="border-b border-gray-200/50 bg-white/80 backdrop-blur-sm">
+  //       <div className="container mx-auto px-4 py-4">
+  //         <div className="flex items-center justify-between">
+  //           <div className="w-20 h-8 bg-gray-200 rounded animate-pulse" />
+  //           <div className="w-24 h-8 bg-gray-200 rounded animate-pulse" />
+  //         </div>
+  //       </div>
+  //     </header>
+  //   );
+  // }
 
   return (
     <header className="border-b border-gray-200/50 bg-white/80 backdrop-blur-sm">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,7 +39,7 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
 
   // 앱 시작 시 인증 상태 초기화
-  restoreAuthFromServer();
+  // restoreAuthFromServer();
 
   root.render(
     <StrictMode>

--- a/frontend/src/routes/auth/email-verification/index.tsx
+++ b/frontend/src/routes/auth/email-verification/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { EmailVerification } from '@/components/auth/EmailVerification';
+
+export const Route = createFileRoute('/auth/email-verification/')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === 'string' ? search.token : undefined,
+  }),
+  component: EmailVerification,
+});

--- a/frontend/src/routes/auth/fail/index.tsx
+++ b/frontend/src/routes/auth/fail/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { EmailVerificationFail } from '@/components/auth/EmailVerificationFail';
+
+export const Route = createFileRoute('/auth/fail/')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    reason: typeof search.reason === 'string' ? (search.reason as string) : undefined,
+  }),
+  component: EmailVerificationFail,
+});

--- a/frontend/src/routes/login/index.tsx
+++ b/frontend/src/routes/login/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { createFileRoute, useRouter, useSearch } from '@tanstack/react-router';
 import { ChevronLeft } from 'lucide-react';
 
 import landingImage from '@/assets/images/landing-1.jpg';
@@ -34,15 +34,15 @@ function LoginPage() {
   }, [isAuthenticated, isLoading, router]);
 
   // 로딩 중이거나 이미 로그인된 상태면 로딩 화면 표시
-  if (isLoading || isAuthenticated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <LoadingSpinner />
-        </div>
-      </div>
-    );
-  }
+  // if (isLoading || isAuthenticated) {
+  //   return (
+  //     <div className="min-h-screen flex items-center justify-center">
+  //       <div className="text-center">
+  //         <LoadingSpinner />
+  //       </div>
+  //     </div>
+  //   );
+  // }
 
   const handleLoginSubmit = (email: string, password: string) => {
     setLoginError('');

--- a/frontend/src/routes/signup/index.tsx
+++ b/frontend/src/routes/signup/index.tsx
@@ -9,6 +9,7 @@ import ErrorMessage from '@/components/auth/ErrorMessage';
 import SignupForm from '@/components/auth/SignupForm';
 import { AUTH_MESSAGES } from '@/constants/messages';
 import { useSendEmailVerificationMutation } from '@/hooks/queries/auth/useAuthMutations';
+import { setPendingSignup } from '@/utils/auth/pendingSignupStorage';
 import { showErrorToast, showSuccessToast, TOAST_MESSAGES } from '@/utils/toast';
 
 export const Route = createFileRoute('/signup/')({

--- a/frontend/src/utils/auth/pendingSignupStorage.ts
+++ b/frontend/src/utils/auth/pendingSignupStorage.ts
@@ -1,0 +1,39 @@
+// 회원가입을 위한 이메일과 비밀번호 임시 저장 (localStorage)
+export interface PendingSignup {
+  email: string;
+  password: string;
+}
+
+const KEY = 'pending-signup';
+
+export function setPendingSignup(data: PendingSignup) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(data));
+  } catch {
+    /* empty */
+  }
+}
+
+export function getPendingSignup(): PendingSignup | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as PendingSignup;
+    if (typeof parsed.email === 'string' && typeof parsed.password === 'string') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingSignup() {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* empty */
+  }
+}

--- a/frontend/src/utils/toast.ts
+++ b/frontend/src/utils/toast.ts
@@ -62,6 +62,8 @@ export const TOAST_MESSAGES = {
     LOGOUT_SUCCESS: '로그아웃되었습니다.',
     SIGNUP_EMAIL_VERIFICATION: '회원가입 메일이 전송되었습니다. 이메일을 확인해주세요.',
     SIGNUP_FAILED: '회원가입에 실패했습니다. 이메일과 비밀번호를 확인해주세요.',
+    EMAIL_VERIFICATION: '이메일 인증에 성공했습니다.',
+    SIGNUP_SUCCESS: '회원가입 성공!',
   },
 
   ERROR: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "ourHour",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## 📌 제목
feat(fe/be): 이메일 인증 관련 프론트 및 백엔드 구현

## 🔗 관련 이슈
- Close #이슈번호

## ✅ 작업 내용
- 이메일 중복 확인 API 및 프론트엔드 적용 (백엔드 및 프론트엔드)
- 이메일 중복 체크 인증 필터 적용 제외, 인증 링크 변경 (프론트 url로) (백엔드)
- 이메일 링크 발송 -> 이메일 인증 -> 자동 회원가입 -> 로그인 페이지로 라우팅 구현 (프론트엔드)

## 📝 기타 참고 사항
- 회원가입 시 계정이 두 개 등록되면 안되기 때문에 React Strict mode를 해당 호출 부분에서만 껐습니다.
- 공개 API의 경우 /auth/token API가 적용되면 안되므로 제외 링크 추가 

