### PR TITLE
fix(be): 채팅 controller 참가자 삭제 메서드 파라미터명 수정

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
@@ -134,9 +134,9 @@ public class ChatRestController {
     public ResponseEntity<ApiResponse<Void>> deleteChatRoomParticipant(
             @OrgId @PathVariable Long orgId,
             @PathVariable Long roomId,
-            @PathVariable Long memberIdToDelete) {
+            @PathVariable Long memberId) {
 
-        chatService.deleteChatRoomParticipant(orgId, roomId, memberIdToDelete);
+        chatService.deleteChatRoomParticipant(orgId, roomId, memberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "참여자 삭제에 성공했습니다."));
     }


### PR DESCRIPTION

## 🔗 관련 이슈
- #154 

## ✅ 작업 내용
- `ChatRestController`의 참여자 삭제 메서드의 파라미터 명을 수정하였습니다.

## 📝 기타 참고 사항
- x

