### PR TITLE
chore: 로컬용 docker-compose 수정-db 생성 후 backend container 동작 보장

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,7 @@ services:
 
   # backend
   backend:
+    build: ./backend
     container_name: dev-backend
     volumes:
       - ./backend:/app
@@ -10,7 +11,8 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: dev
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   # db
   db:
@@ -24,7 +26,7 @@ services:
       - ./backend/.env
     environment:
       SPRING_PROFILES_ACTIVE: dev
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      timeout: 20s
+      retries: 10

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -2,6 +2,7 @@ services:
 
   # backend
   backend:
+    build: ./backend
     container_name: release-backend
     environment:
       SPRING_PROFILES_ACTIVE: release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,5 @@ services:
 
   # backend
   backend:
-    build: ./backend
     ports:
       - "8080:8080"
-
-
-


### PR DESCRIPTION
## 📌 제목
chore: 로컬용 docker-compose 수정-db 생성 후 backend container 동작 보장

## 🔗 관련 이슈
- Close #이슈번호

## ✅ 작업 내용
- 로컬용 docker-compose.dev.yml에서 db 생성 후 backend docker 실행될 수 있도록 보장
- build: ./backend 공용 docker-compose.yml 분리
- CI/CD 파이프라인 구축 후 docker-compose.release.yml에서 속도 개선을 위해 build가 아닌 image로 수정 예정

## 📝 기타 참고 사항

