### PR TITLE
fix: docker build-Error: Unable to access jarfile app.jar 해결

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,6 @@ RUN ./gradlew clean build -x test
 # Runtime Stage
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY --from=build /app/build/libs/backend-0.0.1-SNAPSHOT.jar /app/build/libs/backend-0.0.1-SNAPSHOT.jar
+COPY --from=build /app/build/libs/backend-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/build/libs/backend-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,6 @@ services:
   backend:
     build: ./backend
     container_name: dev-backend
-    volumes:
-      - ./backend:/app
     env_file:
       - ./backend/.env
     environment:


### PR DESCRIPTION
## 📌 제목
fix: docker build-Error: Unable to access jarfile app.jar 해결

## 🔗 관련 이슈
-

## ✅ 작업 내용
- volume 설정으로 인해 로컬의 소스 코드가 컨테이너 내부의 /app 디렉터리를 덮어 씀.
- Error: Unable to access jarfile app.jar 오류 발생
- docker-compose.dev.yml에서 volume 설정 삭제

## 📝 기타 참고 사항
- 코드 수정 시 hot reload가 안 될 수 있으므로 코드 수정한 것이 반영이 안 됐을 시 새로 고침 하기
