### PR TITLE
feat(be): 깃허브-유저 연동 기능 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/member/dto/MyMemberInfoResDTO.java
@@ -20,5 +20,6 @@ public class MyMemberInfoResDTO {
     private String deptName;
     private String positionName;
     private String role;
+    private Boolean isGithubLinked;
 
 }

--- a/backend/src/main/java/com/ourhour/domain/project/exception/GithubException.java
+++ b/backend/src/main/java/com/ourhour/domain/project/exception/GithubException.java
@@ -1,0 +1,64 @@
+package com.ourhour.domain.project.exception;
+
+import com.ourhour.global.exception.BusinessException;
+import com.ourhour.global.exception.ErrorCode;
+
+public class GithubException extends BusinessException {
+
+    public GithubException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public GithubException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public static GithubException githubTokenNotFoundException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_NOT_FOUND);
+    }
+
+    public static GithubException githubTokenSaveFailedException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_SAVE_FAILED);
+    }
+
+    public static GithubException githubTokenUpdateFailedException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_UPDATE_FAILED);
+    }
+
+    public static GithubException githubTokenDeleteFailedException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_DELETE_FAILED);
+    }
+
+    public static GithubException githubTokenNotMatchException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_NOT_MATCH);
+    }
+
+    public static GithubException githubTokenNotAuthorizedException() {
+        return new GithubException(ErrorCode.GITHUB_TOKEN_NOT_AUTHORIZED);
+    }
+
+    public static GithubException githubRepositoryNotFoundException() {
+        return new GithubException(ErrorCode.GITHUB_REPOSITORY_NOT_FOUND);
+    }
+
+    public static GithubException githubRepositoryAlreadyConnectedException() {
+        return new GithubException(ErrorCode.GITHUB_REPOSITORY_ALREADY_CONNECTED);
+    }
+
+    public static GithubException githubMilestoneListNotFoundException() {
+        return new GithubException(ErrorCode.GITHUB_MILESTONE_LIST_NOT_FOUND);
+    }
+
+    public static GithubException githubRepositoryAccessDeniedException() {
+        return new GithubException(ErrorCode.GITHUB_REPOSITORY_ACCESS_DENIED);
+    }
+
+    public static GithubException invalidRepositoryFormatException() {
+        return new GithubException(ErrorCode.INVALID_REPOSITORY_FORMAT);
+    }
+
+    public static GithubException githubSyncFailedException() {
+        return new GithubException(ErrorCode.GITHUB_SYNC_FAILED);
+    }
+
+}

--- a/backend/src/main/java/com/ourhour/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/ourhour/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ourhour.domain.user.controller;
 
+import com.ourhour.domain.user.dto.GitHubCodeReqDTO;
 import com.ourhour.domain.user.dto.PwdChangeReqDTO;
 import com.ourhour.domain.user.dto.PwdVerifyReqDTO;
 import com.ourhour.domain.user.service.UserService;
@@ -21,6 +22,7 @@ public class UserController {
 
     private final UserService userService;
 
+    // 비밀번호 변경
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> changePwd(@Valid @RequestBody PwdChangeReqDTO pwdChangeReqDTO) {
 
@@ -32,6 +34,7 @@ public class UserController {
 
     }
 
+    // 비밀번호 확인
     @PostMapping("/password-verification")
     public ResponseEntity<ApiResponse<Void>> verifyPwd(@Valid @RequestBody PwdVerifyReqDTO pwdVerifyReqDTO) {
 
@@ -43,6 +46,7 @@ public class UserController {
 
     }
 
+    // 계정 탈퇴
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> deleteUser(@Valid @RequestBody PwdVerifyReqDTO pwdVerifyReqDTO) {
 
@@ -54,5 +58,26 @@ public class UserController {
 
     }
 
+    // 깃허브 연동
+    @PostMapping("/github/exchange-code")
+    public ResponseEntity<ApiResponse<Void>> exchangeGithubCode(
+            @Valid @RequestBody GitHubCodeReqDTO req) {
+        userService.exchangeGithubCodeAndConnect(req);
+
+        ApiResponse<Void> response = ApiResponse.success(null, "깃허브 연동이 완료되었습니다.");
+        return ResponseEntity.ok(response);
+    }
+
+    // 깃허브 연동 해제
+    @DeleteMapping("/github/disconnect")
+    public ResponseEntity<ApiResponse<Void>> disconnectGitHub() {
+
+        userService.disconnectGitHub();
+
+        ApiResponse<Void> response = ApiResponse.success(null, "깃허브 연동이 해제되었습니다.");
+
+        return ResponseEntity.ok(response);
+
+    }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/user/dto/GitHubCodeReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/user/dto/GitHubCodeReqDTO.java
@@ -1,0 +1,21 @@
+package com.ourhour.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubCodeReqDTO {
+
+    @NotBlank(message = "GitHub authorization code는 필수입니다.")
+    private String code;
+
+    @NotBlank(message = "GitHub redirect URI는 필수입니다.")
+    private String redirectUri;
+
+}

--- a/backend/src/main/java/com/ourhour/domain/user/dto/GitHubConnectReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/user/dto/GitHubConnectReqDTO.java
@@ -1,0 +1,17 @@
+package com.ourhour.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitHubConnectReqDTO {
+
+    @NotBlank(message = "GitHub 액세스 토큰은 필수입니다.")
+    private String accessToken;
+}

--- a/backend/src/main/java/com/ourhour/domain/user/dto/GitHubUserInfoDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/user/dto/GitHubUserInfoDTO.java
@@ -1,0 +1,17 @@
+package com.ourhour.domain.user.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GitHubUserInfoDTO {
+
+    private String githubUsername;
+    private String githubEmail;
+    private Boolean verified;
+    private LocalDateTime linkedAt;
+
+}

--- a/backend/src/main/java/com/ourhour/domain/user/entity/GitHubTokenEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/user/entity/GitHubTokenEntity.java
@@ -1,0 +1,35 @@
+package com.ourhour.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_github_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GitHubTokenEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "access_token", nullable = false)
+    private String githubAccessToken;
+
+    @Builder
+    public GitHubTokenEntity(Long userId, String githubAccessToken) {
+        this.userId = userId;
+        setAccessToken(githubAccessToken);
+    }
+
+    private void setAccessToken(String accessToken) {
+        this.githubAccessToken = accessToken;
+    }
+
+    public void updateToken(String accessToken) {
+        this.githubAccessToken = accessToken;
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/user/entity/UserEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/user/entity/UserEntity.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name="tbl_user")
+@Table(name = "tbl_user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
@@ -33,6 +33,9 @@ public class UserEntity {
     @OneToMany(mappedBy = "acceptedUserEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrgInvEntity> orgInvEntityList = new ArrayList<>();
 
+    @OneToOne(mappedBy = "userEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    private UserGitHubMappingEntity githubMappingEntity;
+
     private String email;
 
     private String password;
@@ -47,7 +50,8 @@ public class UserEntity {
     private boolean isDeleted;
 
     @Builder
-    public UserEntity(String email, String password, Platform platform, boolean isEmailVerified, LocalDateTime emailVerifiedAt) {
+    public UserEntity(String email, String password, Platform platform, boolean isEmailVerified,
+            LocalDateTime emailVerifiedAt) {
         this.email = email;
         this.password = password;
         this.platform = platform;
@@ -61,6 +65,10 @@ public class UserEntity {
 
     public void markAsDeleted() {
         this.isDeleted = true;
+    }
+
+    public void removeGithubMapping() {
+        this.githubMappingEntity = null;
     }
 
 }

--- a/backend/src/main/java/com/ourhour/domain/user/entity/UserGitHubMappingEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/user/entity/UserGitHubMappingEntity.java
@@ -1,0 +1,58 @@
+package com.ourhour.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_user_github_mapping")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserGitHubMappingEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId; // UserEntity의 ID 참조 (기본키)
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true, insertable = false, updatable = false)
+    private UserEntity userEntity; // UserEntity 참조
+
+    @Column(name = "github_username", nullable = false)
+    private String githubUsername; // GitHub 사용자명 (e.g., "hong-gildong")
+
+    @Column(name = "github_email")
+    private String githubEmail; // GitHub 이메일 (선택적, 검증용)
+
+    @Column(name = "verified", nullable = false)
+    @Builder.Default
+    private Boolean verified = false; // 연동 검증 여부
+
+    @Column(name = "linked_at")
+    private LocalDateTime linkedAt; // 연동 시각
+
+    public void setGithubUsername(String githubUsername) {
+        this.githubUsername = githubUsername;
+    }
+
+    public void setGithubEmail(String githubEmail) {
+        this.githubEmail = githubEmail;
+    }
+
+    public void verify() {
+        this.verified = true;
+        this.linkedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/user/repository/GitHubTokenRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/user/repository/GitHubTokenRepository.java
@@ -1,0 +1,7 @@
+package com.ourhour.domain.user.repository;
+
+import com.ourhour.domain.user.entity.GitHubTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GitHubTokenRepository extends JpaRepository<GitHubTokenEntity, Long> {
+}

--- a/backend/src/main/java/com/ourhour/domain/user/repository/UserGitHubMappingRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/user/repository/UserGitHubMappingRepository.java
@@ -1,0 +1,17 @@
+package com.ourhour.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Repository;
+
+import com.ourhour.domain.user.entity.UserGitHubMappingEntity;
+
+@Repository
+public interface UserGitHubMappingRepository extends JpaRepository<UserGitHubMappingEntity, Long> {
+    Optional<UserGitHubMappingEntity> findByUserId(Long userId);
+
+    @Transactional
+    long deleteByUserId(Long userId);
+}

--- a/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ourhour/domain/user/service/UserService.java
@@ -1,11 +1,23 @@
 package com.ourhour.domain.user.service;
 
+import com.ourhour.domain.user.dto.GitHubConnectReqDTO;
+import com.ourhour.domain.user.dto.GitHubCodeReqDTO;
+import com.ourhour.domain.user.dto.GitHubUserInfoDTO;
+import com.ourhour.domain.user.entity.GitHubTokenEntity;
+import com.ourhour.domain.auth.exception.AuthException;
+import com.ourhour.domain.user.entity.UserGitHubMappingEntity;
+import com.ourhour.domain.user.repository.GitHubTokenRepository;
+import com.ourhour.domain.user.repository.UserGitHubMappingRepository;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.util.UserContextHolder;
+import com.ourhour.global.util.EncryptionUtil;
 import com.ourhour.domain.auth.repository.EmailVerificationRepository;
 import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.org.enums.Status;
 import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.domain.org.service.OrgRoleGuardService;
+import com.ourhour.domain.project.exception.GithubException;
 import com.ourhour.domain.user.dto.PwdChangeReqDTO;
 import com.ourhour.domain.user.dto.PwdVerifyReqDTO;
 import com.ourhour.domain.user.entity.UserEntity;
@@ -14,8 +26,19 @@ import com.ourhour.domain.user.util.PasswordVerifier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.ourhour.domain.user.exception.UserException.*;
@@ -31,6 +54,18 @@ public class UserService {
     private final MemberRepository memberRepository;
     private final OrgRoleGuardService orgRoleGuardService;
     private final OrgParticipantMemberRepository orgParticipantMemberRepository;
+    private final GitHubTokenRepository gitHubTokenRepository;
+    private final UserGitHubMappingRepository userGitHubMappingRepository;
+    private final EncryptionUtil encryptionUtil;
+
+    @Value("${github.oauth.client-id:${APPLICATION_GITHUB_CLIENT_ID:}}")
+    private String githubClientId;
+
+    @Value("${github.oauth.client-secret:${APPLICATION_GITHUB_CLIENT_SECRET:}}")
+    private String githubClientSecret;
+
+    @Value("${github.oauth.redirect-uri:${APPLICATION_GITHUB_REDIRECT_URI:}}")
+    private String githubRedirectUri;
 
     // 비밀번호 변경
     @Transactional
@@ -91,6 +126,154 @@ public class UserService {
 
         // 탈퇴한 사용자의 인증 이메일 무효화
         emailVerificationRepository.invalidateByEmail(userEntity.getEmail());
+
+    }
+
+    // 깃허브 사용자 정보 조회
+    private GitHubUserInfoDTO fetchGitHubUserInfo(String rawAccessToken) {
+        try {
+            GitHub github = new GitHubBuilder().withOAuthToken(rawAccessToken).build();
+            String username = github.getMyself().getLogin();
+            String email = github.getMyself().getEmail();
+
+            return GitHubUserInfoDTO.builder()
+                    .githubUsername(username)
+                    .githubEmail(email)
+                    .verified(true)
+                    .linkedAt(LocalDateTime.now())
+                    .build();
+        } catch (IOException e) {
+            throw GithubException.githubTokenNotAuthorizedException();
+        }
+    }
+
+    // 깃허브 OAuth code 교환
+    @Transactional
+    public void exchangeGithubCodeAndConnect(GitHubCodeReqDTO req) {
+        String code = req.getCode();
+
+        if (code == null || code.isBlank()) {
+            throw GithubException.githubTokenNotAuthorizedException();
+        }
+
+        String redirectUri = (req.getRedirectUri() != null && !req.getRedirectUri().isBlank())
+                ? req.getRedirectUri()
+                : githubRedirectUri;
+
+        String accessToken = exchangeCodeForAccessToken(code, redirectUri);
+
+        connectGitHub(GitHubConnectReqDTO.builder().accessToken(accessToken).build());
+    }
+
+    // 깃허브 연동
+    @Transactional
+    public void connectGitHub(GitHubConnectReqDTO gitHubConnectReqDTO) {
+        Claims claims = UserContextHolder.get();
+        if (claims == null) {
+            throw AuthException.unauthorizedException();
+        }
+
+        Long userId = claims.getUserId();
+
+        // 1) 액세스 토큰 암호화 저장/업데이트
+        String encrypted = encryptionUtil.encrypt(gitHubConnectReqDTO.getAccessToken());
+
+        GitHubTokenEntity tokenEntity = gitHubTokenRepository.findById(userId).orElse(null);
+
+        if (tokenEntity != null) {
+            tokenEntity.updateToken(encrypted);
+        } else {
+            tokenEntity = GitHubTokenEntity.builder().userId(userId).githubAccessToken(encrypted).build();
+        }
+
+        gitHubTokenRepository.save(tokenEntity);
+
+        // 2) GitHub 사용자 정보 조회 후 매핑 저장 (username, email, verified, linkedAt)
+        GitHubUserInfoDTO gitHubUser = fetchGitHubUserInfo(gitHubConnectReqDTO.getAccessToken());
+
+        UserGitHubMappingEntity mapping = userGitHubMappingRepository.findByUserId(userId)
+                .orElse(UserGitHubMappingEntity.builder().userId(userId).build());
+
+        mapping.setGithubUsername(gitHubUser.getGithubUsername());
+        mapping.setGithubEmail(gitHubUser.getGithubEmail());
+        mapping.verify();
+        userGitHubMappingRepository.save(mapping);
+    }
+
+    // code -> access_token 교환
+    private String exchangeCodeForAccessToken(String code, String redirectUri) {
+        try {
+            // 간단한 HTTP 호출 (Java 11 HttpClient 사용)
+            HttpClient client = HttpClient.newHttpClient();
+            String body = "client_id="
+                    + URLEncoder.encode(githubClientId, StandardCharsets.UTF_8)
+                    + "&client_secret="
+                    + URLEncoder.encode(githubClientSecret, StandardCharsets.UTF_8)
+                    + "&code=" + java.net.URLEncoder.encode(code, StandardCharsets.UTF_8)
+                    + (redirectUri != null
+                            ? "&redirect_uri="
+                                    + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
+                            : "")
+                    + "&grant_type=authorization_code";
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create("https://github.com/login/oauth/access_token"))
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() / 100 != 2) {
+                throw GithubException.githubTokenNotAuthorizedException();
+            }
+
+            // 응답 파싱 { access_token, token_type, scope }
+            // 간단 파서 (의존성 최소화)
+            String json = response.body();
+            String token = parseJsonField(json, "access_token");
+            if (token == null || token.isBlank()) {
+                throw GithubException.githubTokenNotAuthorizedException();
+            }
+            return token;
+        } catch (IOException | InterruptedException e) {
+            throw GithubException.githubTokenNotAuthorizedException();
+        }
+    }
+
+    // JSON 파싱
+    private String parseJsonField(String json, String key) {
+        String pattern = "\"" + key + "\"\s*:\s*\"";
+        java.util.regex.Pattern p = java.util.regex.Pattern.compile(pattern);
+        java.util.regex.Matcher m = p.matcher(json);
+        if (m.find()) {
+            int start = m.end();
+            int end = json.indexOf('"', start);
+            if (end > start) {
+                return json.substring(start, end);
+            }
+        }
+        return null;
+    }
+
+    // 깃허브 연동 해제
+    @Transactional
+    public void disconnectGitHub() {
+        Claims claims = UserContextHolder.get();
+        if (claims == null) {
+            throw AuthException.unauthorizedException();
+        }
+
+        Long userId = claims.getUserId();
+
+        gitHubTokenRepository.deleteById(userId);
+
+        userGitHubMappingRepository.findByUserId(userId).ifPresent(mapping -> {
+            if (mapping.getUserEntity() != null) {
+                mapping.getUserEntity().removeGithubMapping();
+            }
+        });
+        userGitHubMappingRepository.deleteByUserId(userId);
 
     }
 }

--- a/backend/src/main/java/com/ourhour/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ourhour/global/exception/ErrorCode.java
@@ -96,7 +96,21 @@ public enum ErrorCode {
     // ========== 파일 관련 (8000~8999) ==========
     INVALID_FILE_FORMAT("잘못된 파일 형식입니다", 8000, HttpStatus.BAD_REQUEST),
     FILE_SAVE_ERROR("파일 저장 중 오류가 발생했습니다", 8001, HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_BASE64_FORMAT("잘못된 Base64 형식입니다", 8002, HttpStatus.BAD_REQUEST);
+    INVALID_BASE64_FORMAT("잘못된 Base64 형식입니다", 8002, HttpStatus.BAD_REQUEST),
+    
+    // ========== 깃허브 관련 (9000~9999) ==========
+    GITHUB_TOKEN_NOT_FOUND("깃허브 토큰을 찾을 수 없습니다", 9000, HttpStatus.NOT_FOUND),
+    GITHUB_TOKEN_SAVE_FAILED("깃허브 토큰 저장에 실패했습니다", 9001, HttpStatus.INTERNAL_SERVER_ERROR),
+    GITHUB_TOKEN_UPDATE_FAILED("깃허브 토큰 업데이트에 실패했습니다", 9002, HttpStatus.INTERNAL_SERVER_ERROR),
+    GITHUB_TOKEN_DELETE_FAILED("깃허브 토큰 삭제에 실패했습니다", 9003, HttpStatus.INTERNAL_SERVER_ERROR),
+    GITHUB_TOKEN_NOT_MATCH("깃허브 토큰이 일치하지 않습니다", 9004, HttpStatus.BAD_REQUEST),
+    GITHUB_TOKEN_NOT_AUTHORIZED("깃허브 토큰이 인증되지 않았습니다", 9005, HttpStatus.UNAUTHORIZED),
+    GITHUB_REPOSITORY_NOT_FOUND("깃허브 레포지토리를 찾을 수 없습니다", 9006, HttpStatus.NOT_FOUND),
+    GITHUB_REPOSITORY_ALREADY_CONNECTED("이미 깃허브 레포지토리가 연동되어 있습니다", 9007, HttpStatus.BAD_REQUEST),
+    GITHUB_MILESTONE_LIST_NOT_FOUND("깃허브 마일스톤 목록을 찾을 수 없습니다", 9008, HttpStatus.NOT_FOUND),
+    GITHUB_REPOSITORY_ACCESS_DENIED("깃허브 레포지토리에 접근할 수 없습니다", 9009, HttpStatus.FORBIDDEN),
+    INVALID_REPOSITORY_FORMAT("깃허브 레포지토리 형식이 올바르지 않습니다", 9010, HttpStatus.BAD_REQUEST),
+    GITHUB_SYNC_FAILED("깃허브 동기화에 실패했습니다", 9011, HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final int statusCode;

--- a/backend/src/main/java/com/ourhour/global/util/EncryptionUtil.java
+++ b/backend/src/main/java/com/ourhour/global/util/EncryptionUtil.java
@@ -1,0 +1,90 @@
+package com.ourhour.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Component
+public class EncryptionUtil {
+
+    @Value("${encryption.secret-key}")
+    private String secretKey;
+
+    private SecretKeySpec secretKeySpec;
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 16;
+
+    public void init() {
+        try {
+            byte[] key = secretKey.getBytes(StandardCharsets.UTF_8);
+            MessageDigest sha = MessageDigest.getInstance("SHA-256");
+            key = sha.digest(key);
+            key = Arrays.copyOf(key, 32); // AES-256을 위해 32바이트
+            secretKeySpec = new SecretKeySpec(key, "AES");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("암호화 초기화 실패", e);
+        }
+    }
+
+    public String encrypt(String strToEncrypt) {
+        try {
+            if (secretKeySpec == null) {
+                init();
+            }
+
+            // IV 생성
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            SecureRandom random = new SecureRandom();
+            random.nextBytes(iv);
+
+            // GCM 모드로 암호화
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, gcmSpec);
+
+            byte[] encrypted = cipher.doFinal(strToEncrypt.getBytes(StandardCharsets.UTF_8));
+
+            // IV + 암호문을 Base64로 인코딩
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            throw new RuntimeException("암호화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    public String decrypt(String strToDecrypt) {
+        try {
+            if (secretKeySpec == null) {
+                init();
+            }
+
+            // Base64 디코딩
+            byte[] combined = Base64.getDecoder().decode(strToDecrypt);
+
+            // IV와 암호문 분리
+            byte[] iv = Arrays.copyOfRange(combined, 0, GCM_IV_LENGTH);
+            byte[] encrypted = Arrays.copyOfRange(combined, GCM_IV_LENGTH, combined.length);
+
+            // GCM 모드로 복호화
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            GCMParameterSpec gcmSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, gcmSpec);
+
+            return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("복호화 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V10__update_github_sync_and_member_mapping.sql
+++ b/backend/src/main/resources/db/migration/V10__update_github_sync_and_member_mapping.sql
@@ -1,0 +1,64 @@
+-- GitHub 동기화 관련 테이블 업데이트
+
+-- member_github_mapping 테이블 생성
+CREATE TABLE IF NOT EXISTS tbl_user_github_mapping (
+    user_id BIGINT PRIMARY KEY,
+    github_username VARCHAR(255) NOT NULL,
+    github_email VARCHAR(255),
+    verified BOOLEAN NOT NULL DEFAULT FALSE,
+    linked_at TIMESTAMP
+);
+
+-- github_token 테이블 생성 
+CREATE TABLE IF NOT EXISTS tbl_github_token (
+    user_id BIGINT PRIMARY KEY,
+    access_token VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_github_token_user_id FOREIGN KEY (user_id) REFERENCES tbl_user(user_id) ON DELETE CASCADE
+);
+
+-- project_github_integration 테이블 생성 
+CREATE TABLE IF NOT EXISTS tbl_project_github_integration (
+  integration_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  project_id BIGINT NOT NULL,
+  member_id BIGINT NOT NULL,
+  github_repository VARCHAR(255) NOT NULL,
+  github_access_token VARCHAR(255) NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  github_id BIGINT NULL,
+  is_github_synced BOOLEAN NOT NULL DEFAULT FALSE,
+  last_synced_at TIMESTAMP NULL,
+  github_etag VARCHAR(255) NULL,
+  sync_status ENUM('NOT_SYNCED', 'SYNCING', 'SYNCED', 'SYNC_FAILED') NOT NULL DEFAULT 'NOT_SYNCED',
+  CONSTRAINT fk_project_github_integration_project_id FOREIGN KEY (project_id) REFERENCES tbl_project(project_id) ON DELETE CASCADE,
+  CONSTRAINT fk_project_github_integration_member_id FOREIGN KEY (member_id) REFERENCES tbl_member(member_id) ON DELETE CASCADE
+);
+
+-- tbl_issue 테이블에 GitHub 동기화 관련 컬럼 추가
+ALTER TABLE tbl_issue 
+ADD COLUMN github_id BIGINT NULL,
+ADD COLUMN is_github_synced BOOLEAN NOT NULL DEFAULT FALSE,
+ADD COLUMN last_synced_at TIMESTAMP NULL,
+ADD COLUMN github_etag VARCHAR(255) NULL,
+ADD COLUMN sync_status ENUM('NOT_SYNCED', 'SYNCING', 'SYNCED', 'SYNC_FAILED') NOT NULL DEFAULT 'NOT_SYNCED',
+ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- tbl_milestone 테이블에 GitHub 동기화 관련 컬럼 추가
+ALTER TABLE tbl_milestone 
+ADD COLUMN github_id BIGINT NULL,
+ADD COLUMN is_github_synced BOOLEAN NOT NULL DEFAULT FALSE,
+ADD COLUMN last_synced_at TIMESTAMP NULL,
+ADD COLUMN github_etag VARCHAR(255) NULL,
+ADD COLUMN sync_status ENUM('NOT_SYNCED', 'SYNCING', 'SYNCED', 'SYNC_FAILED') NOT NULL DEFAULT 'NOT_SYNCED',
+ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- GitHub 동기화 상태 기본값 설정 (기존 데이터용)
+UPDATE tbl_issue SET sync_status = 'NOT_SYNCED' WHERE sync_status IS NULL;
+UPDATE tbl_milestone SET sync_status = 'NOT_SYNCED' WHERE sync_status IS NULL;
+
+-- GitHub 동기화 여부 기본값 설정 (기존 데이터용)
+UPDATE tbl_issue SET is_github_synced = false WHERE is_github_synced IS NULL;
+UPDATE tbl_milestone SET is_github_synced = false WHERE is_github_synced IS NULL; 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -38,3 +38,13 @@ jwt:
   secret: thisissecretthisissecretthisissecretthisissecretthisissecretthisissecretthisissecretthisissecret
   access-token-validity-in-seconds: 300
   refresh-token-validity-in-seconds: 1000000
+
+encryption:
+  secret-key: thisissecretthisissecretthisissecretthisissecretthisissecretthisissecretthisissecretthisissecretthisissecret
+
+# GitHub OAuth 설정
+github:
+  client-id: 1234567890
+  client-secret: 1234567890
+  redirect-uri: http://localhost:5173/auth/github/callback
+  scope: repo,read:user,user:email


### PR DESCRIPTION
## 📌 제목
feat(be): 깃허브-유저 연동 기능 구현

----------------------------------------

## 🔗 관련 이슈
- Close #190 

## ✅ 작업 내용
- 계정별 1개의 깃허브 계정을 연동할 수 있도록 기능을 구현했습니다.

## 📝 기타 참고 사항
- 소셜로그인에도 비슷하게 사용될 것 같아 해당 기능 구현시 논의 필요
- 깃허브 레포-아워아워 플젝 연동해서 사용하려면 계정에 깃허브 연동이 필요해서 추가하였음

