### PR TITLE
fix: CI-test 및 build 분리

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -57,8 +57,14 @@ jobs:
           echo "APPLICATION_GITHUB_REDIRECT_URI=${{ secrets.APPLICATION_GITHUB_REDIRECT_URI }}" >> $GITHUB_ENV
           echo "APPLICATION_GITHUB_SCOPE=${{ secrets.APPLICATION_GITHUB_SCOPE }}" >> $GITHUB_ENV
 
-      - name: Build with Gradle
-        run: ./gradlew clean build --no-daemon
+      # test
+      - name: Run Tests with Gradle
+        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        working-directory: ./backend
+
+      # test 제외 build
+      - name: Build JAR for Deployment
+        run: ./gradlew clean bootJar --no-daemon
         working-directory: ./backend
 
       - name: Upload JAR artifact

--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -59,7 +59,7 @@ jobs:
 
       # test
       - name: Run Tests with Gradle
-        run: ./gradlew test --no-daemon -Dspring.profiles.active=test
+        run: ./gradlew test --no-daemon
         working-directory: ./backend
 
       # test 제외 build


### PR DESCRIPTION
## 📌 제목
fix: CI-test 및 build 분리

## 🔗 관련 이슈
- 

## ✅ 작업 내용
- 문제: dev 프로필 설정으로 인해 application-test.yml 오버라이드 -> 테스트 실패 
- 해결: CI 단계 시 test와 boot jar 분리

## 📝 기타 참고 사항
- develop 브랜치 및 main 브랜치 push 시 test 동작
