### PR TITLE
feat(fe/be): 댓글 좋아요 기능 구현

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/controller/CommentController.java
@@ -15,7 +15,12 @@ import com.ourhour.domain.comment.dto.CommentCreateReqDTO;
 import com.ourhour.domain.comment.dto.CommentPageResDTO;
 import com.ourhour.domain.comment.dto.CommentUpdateReqDTO;
 import com.ourhour.domain.comment.service.CommentService;
+import com.ourhour.domain.comment.service.CommentLikeService;
 import com.ourhour.global.common.dto.ApiResponse;
+import com.ourhour.global.jwt.util.UserContextHolder;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.domain.org.exception.OrgException;
+
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -24,23 +29,33 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
-@RequestMapping("/api/comments")
+@RequestMapping("/api/org/{orgId}/comments")
 @RequiredArgsConstructor
 @Tag(name = "댓글", description = "댓글 조회/등록/수정/삭제 API")
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
 
     // 댓글 목록 조회
     @GetMapping
     @Operation(summary = "댓글 목록 조회", description = "게시글/이슈 기준으로 댓글 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<CommentPageResDTO>> getComments(
+            @PathVariable Long orgId,
             @RequestParam(required = false) Long postId,
             @RequestParam(required = false) Long issueId,
             @RequestParam(defaultValue = "1") @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.") int currentPage,
             @RequestParam(defaultValue = "10") @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.") @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.") int size) {
 
-        CommentPageResDTO response = commentService.getComments(postId, issueId, currentPage, size);
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        CommentPageResDTO response = commentService.getComments(postId, issueId, currentPage, size, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(response, "댓글 목록 조회에 성공했습니다."));
     }
@@ -49,9 +64,18 @@ public class CommentController {
     @PostMapping
     @Operation(summary = "댓글 등록", description = "새 댓글을 등록합니다.")
     public ResponseEntity<ApiResponse<Void>> createComment(
+            @PathVariable Long orgId,
             @Valid @RequestBody CommentCreateReqDTO commentCreateReqDTO) {
 
-        commentService.createComment(commentCreateReqDTO);
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        commentService.createComment(commentCreateReqDTO, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "댓글 등록에 성공했습니다."));
     }
@@ -60,10 +84,19 @@ public class CommentController {
     @PutMapping("/{commentId}")
     @Operation(summary = "댓글 수정", description = "기존 댓글을 수정합니다.")
     public ResponseEntity<ApiResponse<Void>> updateComment(
+            @PathVariable Long orgId,
             @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId,
             @Valid @RequestBody CommentUpdateReqDTO commentUpdateReqDTO) {
 
-        commentService.updateComment(commentId, commentUpdateReqDTO);
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        commentService.updateComment(commentId, commentUpdateReqDTO, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "댓글 수정에 성공했습니다."));
     }
@@ -72,10 +105,71 @@ public class CommentController {
     @DeleteMapping("/{commentId}")
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long orgId,
             @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId) {
 
-        commentService.deleteComment(commentId);
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        commentService.deleteComment(commentId, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "댓글 삭제에 성공했습니다."));
+    }
+
+    // 댓글 좋아요
+    @PostMapping("/{commentId}/like")
+    @Operation(summary = "댓글 좋아요", description = "댓글에 좋아요를 추가합니다.")
+    public ResponseEntity<ApiResponse<Void>> likeComment(
+            @PathVariable Long orgId,
+            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId,
+            @RequestParam @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.") Long memberId) {
+
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        // 현재 사용자 권한 확인
+        if (!currentMemberId.equals(memberId)) {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+
+        commentLikeService.likeComment(commentId, memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "댓글 좋아요에 성공했습니다."));
+    }
+
+    // 댓글 좋아요 취소
+    @DeleteMapping("/{commentId}/like")
+    @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요를 취소합니다.")
+    public ResponseEntity<ApiResponse<Void>> unlikeComment(
+            @PathVariable Long orgId,
+            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId,
+            @RequestParam @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.") Long memberId) {
+
+        // 현재 사용자 정보 가져오기
+        Claims claims = UserContextHolder.get();
+        Long currentMemberId = claims.getOrgAuthorityList().stream()
+                .filter(org -> org.getOrgId().equals(orgId))
+                .findFirst()
+                .orElseThrow(() -> OrgException.orgNotFoundException())
+                .getMemberId();
+
+        // 현재 사용자 권한 확인
+        if (!currentMemberId.equals(memberId)) {
+            throw new RuntimeException("권한이 없습니다.");
+        }
+
+        commentLikeService.unlikeComment(commentId, memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(null, "댓글 좋아요 취소에 성공했습니다."));
     }
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentCreateReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentCreateReqDTO.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 public class CommentCreateReqDTO {
     private Long postId;
     private Long issueId;
-    private Long authorId;
     private Long parentCommentId;
     private String content;
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentDTO.java
@@ -17,5 +17,7 @@ public class CommentDTO {
     private String profileImgUrl;
     private String content;
     private LocalDateTime createdAt;
+    private Long likeCount;
+    private Boolean isLikedByCurrentUser;
     private List<CommentDTO> childComments;
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentUpdateReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentUpdateReqDTO.java
@@ -9,5 +9,4 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentUpdateReqDTO {
     private String content;
-    private Long authorId;
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/entity/CommentLikeEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/entity/CommentLikeEntity.java
@@ -9,6 +9,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +18,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "tbl_comment_like")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class CommentLikeEntity {
 
     @EmbeddedId
@@ -30,6 +34,5 @@ public class CommentLikeEntity {
     @JoinColumn(name = "member_id")
     @MapsId("memberId")
     private MemberEntity memberEntity;
-
 
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/exception/CommentException.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/exception/CommentException.java
@@ -36,4 +36,12 @@ public class CommentException extends BusinessException {
     public static CommentException commentTargetConflictException() {
         return new CommentException(ErrorCode.COMMENT_TARGET_CONFLICT);
     }
+
+    public static CommentException commentAlreadyLikedException() {
+        return new CommentException(ErrorCode.COMMENT_ALREADY_LIKED);
+    }
+
+    public static CommentException commentLikeNotFoundException() {
+        return new CommentException(ErrorCode.COMMENT_LIKE_NOT_FOUND);
+    }
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/mapper/CommentMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/mapper/CommentMapper.java
@@ -14,58 +14,70 @@ import com.ourhour.domain.comment.dto.CommentDTO;
 import com.ourhour.domain.comment.dto.CommentResDTO;
 import com.ourhour.domain.comment.entity.CommentEntity;
 import com.ourhour.domain.comment.dto.CommentUpdateReqDTO;
+import com.ourhour.domain.comment.service.CommentLikeService;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CommentMapper {
-    
-    // CommentEntity 리스트 -> CommentResDTO
-    default CommentResDTO toCommentResDTO(List<CommentEntity> commentEntities, Long postId, Long issueId) {
-        if (commentEntities == null || commentEntities.isEmpty()) {
-            return new CommentResDTO(postId, issueId, List.of());
-        }
-        
-        // 댓글들을 parentCommentId 기준으로 그룹화
-        Map<Long, List<CommentEntity>> childCommentMap = commentEntities.stream()
-                .filter(comment -> comment.getParentCommentId() != null)
-                .collect(Collectors.groupingBy(CommentEntity::getParentCommentId));
-        
-        // 최상위 댓글만 필터링하고 CommentDTO로 변환
-        List<CommentDTO> topLevelComments = commentEntities.stream()
-                .filter(comment -> comment.getParentCommentId() == null)
-                .map(comment -> toCommentDTO(comment, childCommentMap))
-                .collect(Collectors.toList());
-        
-        return new CommentResDTO(postId, issueId, topLevelComments);
-    }
-    
-    // CommentEntity -> CommentDTO
-    default CommentDTO toCommentDTO(CommentEntity commentEntity, Map<Long, List<CommentEntity>> childCommentMap) {
-        if (commentEntity == null) {
-            return null;
-        }
-        
-        // 대댓글 조회
-        List<CommentEntity> childEntities = childCommentMap.getOrDefault(commentEntity.getCommentId(), List.of());
-        
-        // 대댓글들을 재귀적으로 CommentDTO로 변환(빈 배열은 map이 실행되지 않음 -> 재귀 종료)
-        List<CommentDTO> childComments = childEntities.stream()
-                .map(child -> toCommentDTO(child, childCommentMap))
-                .collect(Collectors.toList());
-        
-        return new CommentDTO(
-            commentEntity.getCommentId(),
-            commentEntity.getAuthorEntity().getMemberId(),
-            commentEntity.getAuthorEntity().getName(),
-            commentEntity.getAuthorEntity().getProfileImgUrl(),
-            commentEntity.getContent(),
-            commentEntity.getCreatedAt(),
-            childComments
-        );
-    }
 
-    // CommentUpdateReqDTO -> CommentEntity
-    @Mapping(target = "postEntity", ignore = true)
-    @Mapping(target = "issueEntity", ignore = true)
-    @Mapping(target = "authorEntity", ignore = true)
-    void updateCommentEntity(@MappingTarget CommentEntity commentEntity, CommentUpdateReqDTO commentUpdateReqDTO);
+        // CommentEntity 리스트 -> CommentResDTO
+        default CommentResDTO toCommentResDTO(List<CommentEntity> commentEntities, Long postId, Long issueId,
+                        CommentLikeService commentLikeService, Long currentMemberId) {
+                if (commentEntities == null || commentEntities.isEmpty()) {
+                        return new CommentResDTO(postId, issueId, List.of());
+                }
+
+                // 댓글들을 parentCommentId 기준으로 그룹화
+                Map<Long, List<CommentEntity>> childCommentMap = commentEntities.stream()
+                                .filter(comment -> comment.getParentCommentId() != null)
+                                .collect(Collectors.groupingBy(CommentEntity::getParentCommentId));
+
+                // 최상위 댓글만 필터링하고 CommentDTO로 변환
+                List<CommentDTO> topLevelComments = commentEntities.stream()
+                                .filter(comment -> comment.getParentCommentId() == null)
+                                .map(comment -> toCommentDTO(comment, childCommentMap, commentLikeService, currentMemberId))
+                                .collect(Collectors.toList());
+
+                return new CommentResDTO(postId, issueId, topLevelComments);
+        }
+
+        // CommentEntity -> CommentDTO
+        default CommentDTO toCommentDTO(CommentEntity commentEntity, Map<Long, List<CommentEntity>> childCommentMap,
+                        CommentLikeService commentLikeService, Long currentMemberId) {
+                if (commentEntity == null) {
+                        return null;
+                }
+
+                // 대댓글 조회
+                List<CommentEntity> childEntities = childCommentMap.getOrDefault(commentEntity.getCommentId(),
+                                List.of());
+
+                // 대댓글들을 재귀적으로 CommentDTO로 변환(빈 배열은 map이 실행되지 않음 -> 재귀 종료)
+                List<CommentDTO> childComments = childEntities.stream()
+                                .map(child -> toCommentDTO(child, childCommentMap, commentLikeService, currentMemberId))
+                                .collect(Collectors.toList());
+
+                // 해당 댓글의 좋아요 수 조회
+                Long likeCount = commentLikeService.getLikeCount(commentEntity.getCommentId());
+
+                // 현재 사용자가 이 댓글을 좋아요했는지 확인
+                Boolean isLikedByCurrentUser = currentMemberId != null ? 
+                                commentLikeService.isLikedByMember(commentEntity.getCommentId(), currentMemberId) : false;
+
+                return new CommentDTO(
+                                commentEntity.getCommentId(),
+                                commentEntity.getAuthorEntity().getMemberId(),
+                                commentEntity.getAuthorEntity().getName(),
+                                commentEntity.getAuthorEntity().getProfileImgUrl(),
+                                commentEntity.getContent(),
+                                commentEntity.getCreatedAt(),
+                                likeCount,
+                                isLikedByCurrentUser,
+                                childComments);
+        }
+
+        // CommentUpdateReqDTO -> CommentEntity
+        @Mapping(target = "postEntity", ignore = true)
+        @Mapping(target = "issueEntity", ignore = true)
+        @Mapping(target = "authorEntity", ignore = true)
+        void updateCommentEntity(@MappingTarget CommentEntity commentEntity, CommentUpdateReqDTO commentUpdateReqDTO);
 }

--- a/backend/src/main/java/com/ourhour/domain/comment/repository/CommentLikeRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,31 @@
+package com.ourhour.domain.comment.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ourhour.domain.comment.entity.CommentLikeEntity;
+import com.ourhour.domain.comment.entity.CommentLikeId;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLikeEntity, CommentLikeId> {
+
+    // 특정 댓글의 좋아요 수 조회
+    @Query("SELECT COUNT(cl) FROM CommentLikeEntity cl WHERE cl.commentLikeId.commentId = :commentId")
+    Long countByCommentId(@Param("commentId") Long commentId);
+
+    // 여러 댓글의 좋아요 수를 한번에 조회
+    @Query("SELECT cl.commentLikeId.commentId, COUNT(cl) FROM CommentLikeEntity cl " +
+            "WHERE cl.commentLikeId.commentId IN :commentIds " +
+            "GROUP BY cl.commentLikeId.commentId")
+    List<Object[]> countByCommentIds(@Param("commentIds") List<Long> commentIds);
+
+    // 특정 사용자가 특정 댓글에 좋아요를 눌렀는지 확인
+    boolean existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId(Long commentId, Long memberId);
+
+    // 특정 사용자의 댓글 좋아요 조회
+    Optional<CommentLikeEntity> findByCommentLikeId_CommentIdAndCommentLikeId_MemberId(Long commentId, Long memberId);
+}
+

--- a/backend/src/main/java/com/ourhour/domain/comment/service/CommentLikeService.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/service/CommentLikeService.java
@@ -1,0 +1,91 @@
+package com.ourhour.domain.comment.service;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ourhour.domain.comment.entity.CommentEntity;
+import com.ourhour.domain.comment.entity.CommentLikeEntity;
+import com.ourhour.domain.comment.entity.CommentLikeId;
+import com.ourhour.domain.comment.repository.CommentLikeRepository;
+import com.ourhour.domain.comment.repository.CommentRepository;
+import com.ourhour.domain.comment.exception.CommentException;
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.repository.MemberRepository;
+import com.ourhour.domain.member.exception.MemberException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+
+    // 댓글 좋아요
+    @CacheEvict(value = "comments", allEntries = true)
+    @Transactional
+    public void likeComment(Long commentId, Long memberId) {
+        
+        // 댓글 존재 확인
+        CommentEntity commentEntity = commentRepository.findById(commentId)
+                .orElseThrow(() -> CommentException.commentNotFoundException());
+
+        // 회원 존재 확인
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> MemberException.memberNotFoundException());
+
+        // 이미 좋아요를 눌렀는지 확인
+        CommentLikeId commentLikeId = new CommentLikeId(commentId, memberId);
+        if (commentLikeRepository.existsById(commentLikeId)) {
+            throw CommentException.commentAlreadyLikedException();
+        }
+
+        // 좋아요 생성
+        CommentLikeEntity commentLikeEntity = CommentLikeEntity.builder()
+                .commentLikeId(commentLikeId)
+                .commentEntity(commentEntity)
+                .memberEntity(memberEntity)
+                .build();
+
+        commentLikeRepository.save(commentLikeEntity);
+    }
+
+    // 댓글 좋아요 취소
+    @CacheEvict(value = "comments", allEntries = true)
+    @Transactional
+    public void unlikeComment(Long commentId, Long memberId) {
+        
+        // 댓글 존재 확인
+        if (!commentRepository.existsById(commentId)) {
+            throw CommentException.commentNotFoundException();
+        }
+
+        // 회원 존재 확인
+        if (!memberRepository.existsById(memberId)) {
+            throw MemberException.memberNotFoundException();
+        }
+
+        // 좋아요 존재 확인
+        CommentLikeId commentLikeId = new CommentLikeId(commentId, memberId);
+        if (!commentLikeRepository.existsById(commentLikeId)) {
+            throw CommentException.commentLikeNotFoundException();
+        }
+
+        // 좋아요 삭제
+        commentLikeRepository.deleteById(commentLikeId);
+    }
+
+    // 댓글 좋아요 수 조회
+    public Long getLikeCount(Long commentId) {
+        return commentLikeRepository.countByCommentId(commentId);
+    }
+
+    // 특정 사용자가 댓글에 좋아요를 눌렀는지 확인
+    public boolean isLikedByMember(Long commentId, Long memberId) {
+        CommentLikeId commentLikeId = new CommentLikeId(commentId, memberId);
+        return commentLikeRepository.existsById(commentLikeId);
+    }
+}

--- a/backend/src/main/java/com/ourhour/domain/project/github/GitHubDtoMapper.java
+++ b/backend/src/main/java/com/ourhour/domain/project/github/GitHubDtoMapper.java
@@ -109,6 +109,7 @@ public class GitHubDtoMapper {
                     comment.getBody(),
                     comment.getCreatedAt().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime(),
                     0L, // GitHub 댓글은 좋아요 수 0으로 초기화
+                    false, // GitHub 댓글은 좋아요 기능 없음
                     List.of());
         } catch (IOException e) {
             log.error("GitHub 댓글 변환 중 오류 발생", e);

--- a/frontend/src/api/comment/commentApi.ts
+++ b/frontend/src/api/comment/commentApi.ts
@@ -12,6 +12,8 @@ export interface Comment {
   profileImgUrl: string;
   content: string;
   createdAt: string;
+  likeCount: number;
+  isLikedByCurrentUser: boolean;
   childComments: Comment[];
 }
 
@@ -36,6 +38,7 @@ export interface CommentPageResponse {
 }
 
 export const getCommentList = async (
+  orgId: number,
   request: GetCommentListRequest,
 ): Promise<ApiResponse<CommentPageResponse>> => {
   try {
@@ -56,7 +59,7 @@ export const getCommentList = async (
       params.append('size', request.size.toString());
     }
 
-    const response = await axiosInstance.get(`/api/comments?${params.toString()}`);
+    const response = await axiosInstance.get(`/api/org/${orgId}/comments?${params.toString()}`);
 
     return response.data;
   } catch (error: unknown) {
@@ -69,16 +72,16 @@ export const getCommentList = async (
 export interface PostCreateCommentRequest {
   postId?: number;
   issueId?: number;
-  authorId: number;
   parentCommentId?: number;
   content: string;
 }
 
 export const postCreateComment = async (
+  orgId: number,
   request: PostCreateCommentRequest,
 ): Promise<ApiResponse<void>> => {
   try {
-    const response = await axiosInstance.post('/api/comments', request);
+    const response = await axiosInstance.post(`/api/org/${orgId}/comments`, request);
 
     return response.data;
   } catch (error: unknown) {
@@ -90,16 +93,19 @@ export const postCreateComment = async (
 // ======== 댓글 수정 ========
 export interface PutUpdateCommentRequest {
   commentId: number;
-  authorId: number;
   content: string;
 }
 
 export const putUpdateComment = async (
+  orgId: number,
   request: PutUpdateCommentRequest,
 ): Promise<ApiResponse<void>> => {
   try {
     const { commentId, ...requestBody } = request;
-    const response = await axiosInstance.put(`/api/comments/${commentId}`, requestBody);
+    const response = await axiosInstance.put(
+      `/api/org/${orgId}/comments/${commentId}`,
+      requestBody,
+    );
     return response.data;
   } catch (error: unknown) {
     logError(error as AxiosError);
@@ -112,9 +118,54 @@ export interface DeleteCommentRequest {
   commentId: number;
 }
 
-export const deleteComment = async (request: DeleteCommentRequest): Promise<ApiResponse<void>> => {
+export const deleteComment = async (
+  orgId: number,
+  request: DeleteCommentRequest,
+): Promise<ApiResponse<void>> => {
   try {
-    const response = await axiosInstance.delete(`/api/comments/${request.commentId}`);
+    const response = await axiosInstance.delete(`/api/org/${orgId}/comments/${request.commentId}`);
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+// ======== 댓글 좋아요 ========
+export interface PostLikeCommentRequest {
+  commentId: number;
+  memberId: number;
+}
+
+export const postLikeComment = async (
+  orgId: number,
+  request: PostLikeCommentRequest,
+): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.post(
+      `/api/org/${orgId}/comments/${request.commentId}/like?memberId=${request.memberId}`,
+    );
+    return response.data;
+  } catch (error: unknown) {
+    logError(error as AxiosError);
+    throw error;
+  }
+};
+
+// ======== 댓글 좋아요 취소 ========
+export interface DeleteLikeCommentRequest {
+  commentId: number;
+  memberId: number;
+}
+
+export const deleteLikeComment = async (
+  orgId: number,
+  request: DeleteLikeCommentRequest,
+): Promise<ApiResponse<void>> => {
+  try {
+    const response = await axiosInstance.delete(
+      `/api/org/${orgId}/comments/${request.commentId}/like?memberId=${request.memberId}`,
+    );
     return response.data;
   } catch (error: unknown) {
     logError(error as AxiosError);

--- a/frontend/src/components/board/CommentSection.tsx
+++ b/frontend/src/components/board/CommentSection.tsx
@@ -9,29 +9,26 @@ import {
   useUpdateCommentMutation,
 } from '@/hooks/queries/comment/useCommentMutations';
 import { useCommentListQuery } from '@/hooks/queries/comment/useCommentQueries';
-import { getMemberIdFromToken } from '@/utils/auth/tokenUtils';
 
 export const CommentSection = () => {
   const { orgId, postId } = useParams({ from: '/org/$orgId/board/$boardId/post/$postId/' });
 
   const { data: commentsData } = useCommentListQuery({
+    orgId: Number(orgId),
     postId: Number(postId),
   });
 
   const comments = (commentsData as unknown as CommentPageResponse)?.comments;
   const totalElements = (commentsData as unknown as CommentPageResponse)?.totalElements;
 
-  const { mutate: createComment } = useCreateCommentMutation(Number(postId), null);
-  const { mutate: updateComment } = useUpdateCommentMutation(Number(postId), null);
-  const { mutate: deleteComment } = useDeleteCommentMutation(Number(postId), null);
-
-  const memberId = getMemberIdFromToken(Number(orgId));
+  const { mutate: createComment } = useCreateCommentMutation(Number(orgId), Number(postId), null);
+  const { mutate: updateComment } = useUpdateCommentMutation(Number(orgId), Number(postId), null);
+  const { mutate: deleteComment } = useDeleteCommentMutation(Number(orgId), Number(postId), null);
 
   const handleCreateComment = (content: string) => {
     createComment({
       content,
       postId: Number(postId),
-      authorId: memberId,
     });
   };
 
@@ -39,7 +36,6 @@ export const CommentSection = () => {
     updateComment({
       commentId,
       content: newContent,
-      authorId: memberId,
     });
   };
 
@@ -61,6 +57,8 @@ export const CommentSection = () => {
             comment={comment}
             onUpdate={handleUpdateComment}
             onDelete={handleDeleteComment}
+            orgId={Number(orgId)}
+            postId={Number(postId)}
           />
         ))}
       </div>

--- a/frontend/src/components/project/issue-detail/CommentSection.tsx
+++ b/frontend/src/components/project/issue-detail/CommentSection.tsx
@@ -9,29 +9,27 @@ import {
   useUpdateCommentMutation,
 } from '@/hooks/queries/comment/useCommentMutations';
 import { useCommentListQuery } from '@/hooks/queries/comment/useCommentQueries';
-import { getMemberIdFromToken } from '@/utils/auth/tokenUtils';
 
 export const CommentSection = () => {
   const { orgId, issueId } = useParams({ from: '/org/$orgId/project/$projectId/issue/$issueId' });
 
   const { data: commentsData } = useCommentListQuery({
+    orgId: Number(orgId),
+    postId: null,
     issueId: Number(issueId),
   });
 
   const comments = (commentsData as unknown as CommentPageResponse)?.comments;
   const totalElements = (commentsData as unknown as CommentPageResponse)?.totalElements;
 
-  const { mutate: createComment } = useCreateCommentMutation(null, Number(issueId));
-  const { mutate: updateComment } = useUpdateCommentMutation(null, Number(issueId));
-  const { mutate: deleteComment } = useDeleteCommentMutation(null, Number(issueId));
-
-  const memberId = getMemberIdFromToken(Number(orgId));
+  const { mutate: createComment } = useCreateCommentMutation(Number(orgId), null, Number(issueId));
+  const { mutate: updateComment } = useUpdateCommentMutation(Number(orgId), null, Number(issueId));
+  const { mutate: deleteComment } = useDeleteCommentMutation(Number(orgId), null, Number(issueId));
 
   const handleCreateComment = (content: string) => {
     createComment({
       content,
       issueId: Number(issueId),
-      authorId: memberId,
     });
   };
 
@@ -39,7 +37,6 @@ export const CommentSection = () => {
     updateComment({
       commentId,
       content: newContent,
-      authorId: memberId,
     });
   };
 
@@ -61,6 +58,8 @@ export const CommentSection = () => {
             comment={comment}
             onUpdate={handleUpdateComment}
             onDelete={handleDeleteComment}
+            orgId={Number(orgId)}
+            issueId={Number(issueId)}
           />
         ))}
       </div>

--- a/frontend/src/hooks/queries/comment/useCommentMutations.ts
+++ b/frontend/src/hooks/queries/comment/useCommentMutations.ts
@@ -5,10 +5,13 @@ import { AxiosError } from 'axios';
 import {
   PostCreateCommentRequest,
   PutUpdateCommentRequest,
-  DeleteCommentRequest,
+  PostLikeCommentRequest,
+  DeleteLikeCommentRequest,
   postCreateComment,
   putUpdateComment,
   deleteComment,
+  postLikeComment,
+  deleteLikeComment,
 } from '@/api/comment/commentApi';
 import { COMMENT_QUERY_KEYS } from '@/constants/queryKeys';
 import { queryClient } from '@/main';
@@ -16,9 +19,13 @@ import { getErrorMessage, logError } from '@/utils/auth/errorUtils';
 import { showErrorToast, showSuccessToast, TOAST_MESSAGES } from '@/utils/toast';
 
 // ======== 댓글 생성 ========
-export const useCreateCommentMutation = (postId?: number | null, issueId?: number | null) =>
+export const useCreateCommentMutation = (
+  orgId: number,
+  postId?: number | null,
+  issueId?: number | null,
+) =>
   useMutation({
-    mutationFn: (request: PostCreateCommentRequest) => postCreateComment(request),
+    mutationFn: (request: PostCreateCommentRequest) => postCreateComment(orgId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [COMMENT_QUERY_KEYS.COMMENT_LIST, postId ?? null, issueId ?? null],
@@ -33,9 +40,13 @@ export const useCreateCommentMutation = (postId?: number | null, issueId?: numbe
   });
 
 // ======== 댓글 수정 ========
-export const useUpdateCommentMutation = (postId?: number | null, issueId?: number | null) =>
+export const useUpdateCommentMutation = (
+  orgId: number,
+  postId?: number | null,
+  issueId?: number | null,
+) =>
   useMutation({
-    mutationFn: (request: PutUpdateCommentRequest) => putUpdateComment(request),
+    mutationFn: (request: PutUpdateCommentRequest) => putUpdateComment(orgId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [COMMENT_QUERY_KEYS.COMMENT_LIST, postId ?? null, issueId ?? null],
@@ -50,15 +61,63 @@ export const useUpdateCommentMutation = (postId?: number | null, issueId?: numbe
   });
 
 // ======== 댓글 삭제 ========
-export const useDeleteCommentMutation = (postId?: number | null, issueId?: number | null) =>
+export const useDeleteCommentMutation = (
+  orgId: number,
+  postId?: number | null,
+  issueId?: number | null,
+) =>
   useMutation({
-    mutationFn: (commentId: number) => deleteComment({ commentId }),
+    mutationFn: (commentId: number) => deleteComment(orgId, { commentId }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [COMMENT_QUERY_KEYS.COMMENT_LIST, postId ?? null, issueId ?? null],
         exact: false,
       });
       showSuccessToast(TOAST_MESSAGES.CRUD.DELETE_SUCCESS);
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      showErrorToast(getErrorMessage(error));
+    },
+  });
+
+// ======== 댓글 좋아요 ========
+export const useLikeCommentMutation = (
+  orgId: number,
+  postId?: number | null,
+  issueId?: number | null,
+  memberId?: number | null,
+) =>
+  useMutation({
+    mutationFn: (request: PostLikeCommentRequest) =>
+      postLikeComment(orgId, { ...request, memberId: memberId ?? 0 }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [COMMENT_QUERY_KEYS.COMMENT_LIST, postId ?? null, issueId ?? null],
+        exact: false,
+      });
+    },
+    onError: (error: AxiosError) => {
+      logError(error);
+      showErrorToast(getErrorMessage(error));
+    },
+  });
+
+// ======== 댓글 좋아요 취소 ========
+export const useUnlikeCommentMutation = (
+  orgId: number,
+  postId?: number | null,
+  issueId?: number | null,
+  memberId?: number | null,
+) =>
+  useMutation({
+    mutationFn: (request: DeleteLikeCommentRequest) =>
+      deleteLikeComment(orgId, { ...request, memberId: memberId ?? 0 }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [COMMENT_QUERY_KEYS.COMMENT_LIST, postId ?? null, issueId ?? null],
+        exact: false,
+      });
     },
     onError: (error: AxiosError) => {
       logError(error);

--- a/frontend/src/hooks/queries/comment/useCommentQueries.ts
+++ b/frontend/src/hooks/queries/comment/useCommentQueries.ts
@@ -5,14 +5,16 @@ import { COMMENT_QUERY_KEYS } from '@/constants/queryKeys';
 
 // ======== 댓글 목록 조회 ========
 interface UseCommentListParams {
-  postId?: number;
-  issueId?: number;
+  orgId: number;
+  postId?: number | null;
+  issueId?: number | null;
   currentPage?: number;
   size?: number;
   enabled?: boolean;
 }
 
 export const useCommentListQuery = ({
+  orgId,
   postId,
   issueId,
   currentPage = 1,
@@ -30,9 +32,9 @@ export const useCommentListQuery = ({
   return useQuery({
     queryKey,
     queryFn: () =>
-      getCommentList({
-        postId,
-        issueId,
+      getCommentList(orgId, {
+        postId: postId ?? undefined,
+        issueId: issueId ?? undefined,
         currentPage,
         size,
       }),


### PR DESCRIPTION
## 📌 제목
feat(fe/be): 댓글 좋아요 기능 구현

----------------------------------------

## 🔗 관련 이슈
- Close #210 

## ✅ 작업 내용
- 댓글 좋아요, 좋아요 취소 api 구현
- 댓글 좋아요, 좋아요 취소 api 연동 및 ui 구현
- 댓글 관련 엔드포인트에 orgId 전부 추가

## 📝 기타 참고 사항


