### PR TITLE
feat(be): 댓글 도메인 단위 테스트 코드 추가

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/controller/CommentController.java
@@ -126,8 +126,7 @@ public class CommentController {
     @Operation(summary = "댓글 좋아요", description = "댓글에 좋아요를 추가합니다.")
     public ResponseEntity<ApiResponse<Void>> likeComment(
             @PathVariable Long orgId,
-            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId,
-            @RequestParam @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.") Long memberId) {
+            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId) {
 
         // 현재 사용자 정보 가져오기
         Claims claims = UserContextHolder.get();
@@ -137,12 +136,7 @@ public class CommentController {
                 .orElseThrow(() -> OrgException.orgNotFoundException())
                 .getMemberId();
 
-        // 현재 사용자 권한 확인
-        if (!currentMemberId.equals(memberId)) {
-            throw new RuntimeException("권한이 없습니다.");
-        }
-
-        commentLikeService.likeComment(commentId, memberId);
+        commentLikeService.likeComment(commentId, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "댓글 좋아요에 성공했습니다."));
     }
@@ -152,8 +146,7 @@ public class CommentController {
     @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요를 취소합니다.")
     public ResponseEntity<ApiResponse<Void>> unlikeComment(
             @PathVariable Long orgId,
-            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId,
-            @RequestParam @Min(value = 1, message = "회원 ID는 1 이상이어야 합니다.") Long memberId) {
+            @PathVariable @Min(value = 1, message = "댓글 ID는 1 이상이어야 합니다.") Long commentId) {
 
         // 현재 사용자 정보 가져오기
         Claims claims = UserContextHolder.get();
@@ -164,11 +157,7 @@ public class CommentController {
                 .getMemberId();
 
         // 현재 사용자 권한 확인
-        if (!currentMemberId.equals(memberId)) {
-            throw new RuntimeException("권한이 없습니다.");
-        }
-
-        commentLikeService.unlikeComment(commentId, memberId);
+        commentLikeService.unlikeComment(commentId, currentMemberId);
 
         return ResponseEntity.ok(ApiResponse.success(null, "댓글 좋아요 취소에 성공했습니다."));
     }

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentCreateReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentCreateReqDTO.java
@@ -3,8 +3,10 @@ package com.ourhour.domain.comment.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentCreateReqDTO {

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentPageResDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentPageResDTO.java
@@ -16,16 +16,16 @@ public class CommentPageResDTO {
     private Long postId;
     private Long issueId;
     private List<CommentDTO> comments;
-    
+
     private int currentPage;
     private int size;
     private int totalPages;
     private long totalElements;
     private boolean hasNext;
     private boolean hasPrevious;
-    
-    public static CommentPageResDTO of(CommentResDTO commentResDTO, int currentPage, int size, 
-                                      int totalPages, long totalElements, boolean hasNext, boolean hasPrevious) {
+
+    public static CommentPageResDTO of(CommentResDTO commentResDTO, int currentPage, int size,
+            int totalPages, long totalElements, boolean hasNext, boolean hasPrevious) {
         return CommentPageResDTO.builder()
                 .postId(commentResDTO.getPostId())
                 .issueId(commentResDTO.getIssueId())
@@ -38,7 +38,7 @@ public class CommentPageResDTO {
                 .hasPrevious(hasPrevious)
                 .build();
     }
-    
+
     public static CommentPageResDTO empty(Long postId, Long issueId, int currentPage, int size) {
         return CommentPageResDTO.builder()
                 .postId(postId)
@@ -49,7 +49,7 @@ public class CommentPageResDTO {
                 .totalPages(0)
                 .totalElements(0)
                 .hasNext(false)
-                .hasPrevious(currentPage > 0)
+                .hasPrevious(currentPage > 1)
                 .build();
     }
-} 
+}

--- a/backend/src/main/java/com/ourhour/domain/comment/dto/CommentUpdateReqDTO.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/dto/CommentUpdateReqDTO.java
@@ -3,8 +3,10 @@ package com.ourhour.domain.comment.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentUpdateReqDTO {

--- a/backend/src/main/java/com/ourhour/domain/comment/entity/CommentEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/entity/CommentEntity.java
@@ -7,10 +7,10 @@ import com.ourhour.domain.project.entity.GitHubSyncableEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class CommentEntity extends GitHubSyncableEntity {
 
     @Id

--- a/backend/src/main/java/com/ourhour/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/ourhour/domain/comment/service/CommentService.java
@@ -1,7 +1,6 @@
 package com.ourhour.domain.comment.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.CacheEvict;
@@ -20,7 +19,6 @@ import com.ourhour.domain.comment.dto.CommentUpdateReqDTO;
 import com.ourhour.domain.comment.repository.CommentRepository;
 import com.ourhour.domain.comment.exception.CommentException;
 import com.ourhour.domain.board.entity.PostEntity;
-import com.ourhour.domain.member.entity.MemberEntity;
 import com.ourhour.domain.member.repository.MemberRepository;
 import com.ourhour.domain.project.entity.IssueEntity;
 import com.ourhour.domain.project.repository.IssueRepository;
@@ -73,7 +71,7 @@ public class CommentService {
 
         CommentPageResDTO result = CommentPageResDTO.of(
                 commentResDTO,
-                parentCommentPage.getNumber(),
+                parentCommentPage.getNumber() + 1,
                 parentCommentPage.getSize(),
                 parentCommentPage.getTotalPages(),
                 parentCommentPage.getTotalElements(),

--- a/backend/src/main/java/com/ourhour/domain/project/entity/GitHubSyncableEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/project/entity/GitHubSyncableEntity.java
@@ -12,12 +12,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @MappedSuperclass
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@SuperBuilder
 public abstract class GitHubSyncableEntity {
 
     /**

--- a/backend/src/main/java/com/ourhour/domain/project/entity/IssueTagEntity.java
+++ b/backend/src/main/java/com/ourhour/domain/project/entity/IssueTagEntity.java
@@ -2,6 +2,8 @@ package com.ourhour.domain.project.entity;
 
 import com.ourhour.global.common.enums.TagColor;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,7 +11,8 @@ import lombok.Setter;
 @Entity
 @Table(name = "tbl_issue_tag")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class IssueTagEntity {
 
     @Id
@@ -28,4 +31,12 @@ public class IssueTagEntity {
     @Setter
     @Enumerated(EnumType.STRING)
     private TagColor color;
+
+    @Builder
+    public IssueTagEntity(Long issueTagId, ProjectEntity projectEntity, String name, TagColor color) {
+        this.issueTagId = issueTagId;
+        this.projectEntity = projectEntity;
+        this.name = name;
+        this.color = color;
+    }
 }

--- a/backend/src/test/java/com/ourhour/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/ourhour/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,259 @@
+package com.ourhour.domain.comment.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import jakarta.servlet.ServletException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ourhour.domain.comment.dto.CommentCreateReqDTO;
+import com.ourhour.domain.comment.dto.CommentDTO;
+import com.ourhour.domain.comment.dto.CommentPageResDTO;
+import com.ourhour.domain.comment.dto.CommentUpdateReqDTO;
+import com.ourhour.domain.comment.service.CommentLikeService;
+import com.ourhour.domain.comment.service.CommentService;
+import com.ourhour.domain.org.enums.Role;
+import com.ourhour.global.jwt.dto.Claims;
+import com.ourhour.global.jwt.dto.OrgAuthority;
+import com.ourhour.global.jwt.util.UserContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentController 테스트")
+class CommentControllerTest {
+
+    @Mock
+    private CommentService commentService;
+
+    @Mock
+    private CommentLikeService commentLikeService;
+
+    @InjectMocks
+    private CommentController commentController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    private static final Long ORG_ID = 1L;
+    private static final Long MEMBER_ID = 1L;
+    private static final Long COMMENT_ID = 1L;
+    private static final Long POST_ID = 1L;
+    private static final Long ISSUE_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(commentController).build();
+        objectMapper = new ObjectMapper();
+    }
+
+    private Claims createMockClaims() {
+        OrgAuthority orgAuthority = new OrgAuthority(ORG_ID, MEMBER_ID, Role.MEMBER);
+        return new Claims("test@example.com", 1L, List.of(orgAuthority));
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회 - 성공 (postId 기준)")
+    void getComments_Success_WithPostId() throws Exception {
+        // Given
+        CommentDTO commentDTO = new CommentDTO(
+                COMMENT_ID,
+                MEMBER_ID,
+                "테스트 사용자",
+                "profile.jpg",
+                "테스트 댓글 내용",
+                LocalDateTime.now(),
+                5L,
+                true,
+                List.of());
+
+        CommentPageResDTO responseDTO = CommentPageResDTO.builder()
+                .postId(POST_ID)
+                .issueId(null)
+                .comments(List.of(commentDTO))
+                .currentPage(1)
+                .size(10)
+                .totalPages(1)
+                .totalElements(1)
+                .hasNext(false)
+                .hasPrevious(false)
+                .build();
+
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            given(commentService.getComments(eq(POST_ID), eq(null), eq(1), eq(10), eq(MEMBER_ID)))
+                    .willReturn(responseDTO);
+
+            // When & Then
+            mockMvc.perform(get("/api/org/{orgId}/comments", ORG_ID)
+                    .param("postId", POST_ID.toString())
+                    .param("currentPage", "1")
+                    .param("size", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.postId").value(POST_ID))
+                    .andExpect(jsonPath("$.data.comments").isArray())
+                    .andExpect(jsonPath("$.data.comments[0].commentId").value(COMMENT_ID));
+
+            then(commentService).should().getComments(eq(POST_ID), eq(null), eq(1), eq(10), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 등록 - 성공")
+    void createComment_Success() throws Exception {
+        // Given
+        CommentCreateReqDTO createReqDTO = new CommentCreateReqDTO(POST_ID, null, null, "새로운 댓글");
+
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            willDoNothing().given(commentService).createComment(any(CommentCreateReqDTO.class), eq(MEMBER_ID));
+
+            // When & Then
+            mockMvc.perform(post("/api/org/{orgId}/comments", ORG_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(createReqDTO)))
+                    .andExpect(status().isOk());
+
+            then(commentService).should().createComment(any(CommentCreateReqDTO.class), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 수정 - 성공")
+    void updateComment_Success() throws Exception {
+        // Given
+        CommentUpdateReqDTO updateReqDTO = new CommentUpdateReqDTO("수정된 댓글 내용");
+
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            willDoNothing().given(commentService).updateComment(eq(COMMENT_ID), any(CommentUpdateReqDTO.class),
+                    eq(MEMBER_ID));
+
+            // When & Then
+            mockMvc.perform(put("/api/org/{orgId}/comments/{commentId}", ORG_ID, COMMENT_ID)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateReqDTO)))
+                    .andExpect(status().isOk());
+
+            then(commentService).should().updateComment(eq(COMMENT_ID), any(CommentUpdateReqDTO.class), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 - 성공")
+    void deleteComment_Success() throws Exception {
+        // Given
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            willDoNothing().given(commentService).deleteComment(eq(COMMENT_ID), eq(MEMBER_ID));
+
+            // When & Then
+            mockMvc.perform(delete("/api/org/{orgId}/comments/{commentId}", ORG_ID, COMMENT_ID))
+                    .andExpect(status().isOk());
+
+            then(commentService).should().deleteComment(eq(COMMENT_ID), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 - 성공")
+    void likeComment_Success() throws Exception {
+        // Given
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            willDoNothing().given(commentLikeService).likeComment(eq(COMMENT_ID), eq(MEMBER_ID));
+
+            // When & Then
+            mockMvc.perform(post("/api/org/{orgId}/comments/{commentId}/like", ORG_ID, COMMENT_ID))
+                    .andExpect(status().isOk());
+
+            then(commentLikeService).should().likeComment(eq(COMMENT_ID), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 - 성공")
+    void unlikeComment_Success() throws Exception {
+        // Given
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(createMockClaims());
+            willDoNothing().given(commentLikeService).unlikeComment(eq(COMMENT_ID), eq(MEMBER_ID));
+
+            // When & Then
+            mockMvc.perform(delete("/api/org/{orgId}/comments/{commentId}/like", ORG_ID, COMMENT_ID))
+                    .andExpect(status().isOk());
+
+            then(commentLikeService).should().unlikeComment(eq(COMMENT_ID), eq(MEMBER_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 목록 조회 - 실패 (조직 권한 없음)")
+    void getComments_Fail_NoOrgAuth() throws Exception {
+        // Given
+        Claims claimsWithoutOrg = new Claims("test@example.com", 1L, List.of());
+
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(claimsWithoutOrg);
+
+            // When & Then - 예외가 발생하는지 확인
+            try {
+                mockMvc.perform(get("/api/org/{orgId}/comments", ORG_ID)
+                        .param("postId", POST_ID.toString()));
+            } catch (Exception e) {
+                // 예외가 발생하면 테스트 성공 (예상된 동작)
+                assertThat(e).isNotNull();
+                return;
+            }
+            // 예외가 발생하지 않으면 실패
+            fail("Expected exception was not thrown");
+        }
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 - 실패 (조직 권한 없음)")
+    void likeComment_Fail_NoOrgAuth() throws Exception {
+        // Given
+        Claims claimsWithoutOrg = new Claims("test@example.com", 1L, List.of());
+
+        try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+            mockedUserContext.when(UserContextHolder::get).thenReturn(claimsWithoutOrg);
+
+            // When & Then - 예외가 발생하는지 확인
+            try {
+                mockMvc.perform(post("/api/org/{orgId}/comments/{commentId}/like", ORG_ID, COMMENT_ID));
+            } catch (Exception e) {
+                // 예외가 발생하면 테스트 성공 (예상된 동작)
+                assertThat(e).isNotNull();
+                return;
+            }
+            // 예외가 발생하지 않으면 실패
+            fail("Expected exception was not thrown");
+        }
+    }
+}

--- a/backend/src/test/java/com/ourhour/domain/comment/repository/CommentLikeRepositoryTest.java
+++ b/backend/src/test/java/com/ourhour/domain/comment/repository/CommentLikeRepositoryTest.java
@@ -1,0 +1,231 @@
+package com.ourhour.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ourhour.domain.comment.entity.CommentLikeEntity;
+import com.ourhour.domain.comment.entity.CommentLikeId;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentLikeRepository 테스트")
+class CommentLikeRepositoryTest {
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Test
+    @DisplayName("댓글 좋아요 저장")
+    void save() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 2L;
+        CommentLikeId likeId = new CommentLikeId(commentId, memberId);
+        CommentLikeEntity commentLike = CommentLikeEntity.builder()
+                .commentLikeId(likeId)
+                .build();
+
+        given(commentLikeRepository.save(commentLike)).willReturn(commentLike);
+
+        // when
+        CommentLikeEntity savedLike = commentLikeRepository.save(commentLike);
+
+        // then
+        assertThat(savedLike.getCommentLikeId().getCommentId()).isEqualTo(commentId);
+        assertThat(savedLike.getCommentLikeId().getMemberId()).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("특정 댓글의 좋아요 수 조회")
+    void countByCommentId() {
+        // given
+        Long commentId = 1L;
+        Long expectedCount = 3L;
+
+        given(commentLikeRepository.countByCommentId(commentId)).willReturn(expectedCount);
+
+        // when
+        Long likeCount = commentLikeRepository.countByCommentId(commentId);
+
+        // then
+        assertThat(likeCount).isEqualTo(expectedCount);
+    }
+
+    @Test
+    @DisplayName("좋아요가 없는 댓글의 좋아요 수 조회")
+    void countByCommentId_NoLikes() {
+        // given
+        Long commentId = 1L;
+        Long expectedCount = 0L;
+
+        given(commentLikeRepository.countByCommentId(commentId)).willReturn(expectedCount);
+
+        // when
+        Long likeCount = commentLikeRepository.countByCommentId(commentId);
+
+        // then
+        assertThat(likeCount).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("여러 댓글의 좋아요 수를 한번에 조회")
+    void countByCommentIds() {
+        // given
+        List<Long> commentIds = List.of(1L, 2L);
+        List<Object[]> expectedResults = Arrays.asList(
+                new Object[]{1L, 2L}, // commentId: 1L, count: 2L
+                new Object[]{2L, 1L}  // commentId: 2L, count: 1L
+        );
+
+        given(commentLikeRepository.countByCommentIds(commentIds)).willReturn(expectedResults);
+
+        // when
+        List<Object[]> results = commentLikeRepository.countByCommentIds(commentIds);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)[0]).isEqualTo(1L); // commentId
+        assertThat(results.get(0)[1]).isEqualTo(2L); // count
+        assertThat(results.get(1)[0]).isEqualTo(2L); // commentId
+        assertThat(results.get(1)[1]).isEqualTo(1L); // count
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 특정 댓글에 좋아요를 눌렀는지 확인 - 존재하는 경우")
+    void existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId_Exists() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentLikeRepository.existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId))
+                .willReturn(true);
+
+        // when
+        boolean exists = commentLikeRepository.existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 특정 댓글에 좋아요를 눌렀는지 확인 - 존재하지 않는 경우")
+    void existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId_NotExists() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentLikeRepository.existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId))
+                .willReturn(false);
+
+        // when
+        boolean exists = commentLikeRepository.existsByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("특정 사용자의 댓글 좋아요 조회 - 존재하는 경우")
+    void findByCommentLikeId_CommentIdAndCommentLikeId_MemberId_Found() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentLikeId likeId = new CommentLikeId(commentId, memberId);
+        CommentLikeEntity commentLike = CommentLikeEntity.builder()
+                .commentLikeId(likeId)
+                .build();
+
+        given(commentLikeRepository.findByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId))
+                .willReturn(Optional.of(commentLike));
+
+        // when
+        Optional<CommentLikeEntity> result = commentLikeRepository
+                .findByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getCommentLikeId()).isEqualTo(likeId);
+    }
+
+    @Test
+    @DisplayName("특정 사용자의 댓글 좋아요 조회 - 존재하지 않는 경우")
+    void findByCommentLikeId_CommentIdAndCommentLikeId_MemberId_NotFound() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentLikeRepository.findByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId))
+                .willReturn(Optional.empty());
+
+        // when
+        Optional<CommentLikeEntity> result = commentLikeRepository
+                .findByCommentLikeId_CommentIdAndCommentLikeId_MemberId(commentId, memberId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 삭제")
+    void delete() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentLikeId likeId = new CommentLikeId(commentId, memberId);
+
+        given(commentLikeRepository.existsById(likeId)).willReturn(false);
+
+        // when
+        commentLikeRepository.deleteById(likeId);
+
+        // then
+        verify(commentLikeRepository).deleteById(likeId);
+        
+        boolean exists = commentLikeRepository.existsById(likeId);
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 존재 확인 - 존재하는 경우")
+    void existsById_Exists() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentLikeId likeId = new CommentLikeId(commentId, memberId);
+
+        given(commentLikeRepository.existsById(likeId)).willReturn(true);
+
+        // when
+        boolean exists = commentLikeRepository.existsById(likeId);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 존재 확인 - 존재하지 않는 경우")
+    void existsById_NotExists() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+        CommentLikeId likeId = new CommentLikeId(commentId, memberId);
+
+        given(commentLikeRepository.existsById(likeId)).willReturn(false);
+
+        // when
+        boolean exists = commentLikeRepository.existsById(likeId);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+}

--- a/backend/src/test/java/com/ourhour/domain/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/ourhour/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,227 @@
+package com.ourhour.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.ourhour.domain.comment.entity.CommentEntity;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentRepository 테스트")
+class CommentRepositoryTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("게시글의 최상위 댓글 페이징 조회")
+    void findByPostIdAndParentCommentIdIsNull() {
+        // given
+        Long postId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        
+        CommentEntity comment1 = CommentEntity.builder()
+                .commentId(1L)
+                .content("첫 번째 댓글")
+                .parentCommentId(null)
+                .build();
+        
+        CommentEntity comment2 = CommentEntity.builder()
+                .commentId(2L)
+                .content("두 번째 댓글")
+                .parentCommentId(null)
+                .build();
+        
+        List<CommentEntity> comments = Arrays.asList(comment1, comment2);
+        Page<CommentEntity> commentPage = new PageImpl<>(comments, pageable, comments.size());
+        
+        given(commentRepository.findByPostIdAndParentCommentIdIsNull(postId, pageable))
+                .willReturn(commentPage);
+
+        // when
+        Page<CommentEntity> result = commentRepository.findByPostIdAndParentCommentIdIsNull(postId, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(CommentEntity::getContent)
+                .containsExactly("첫 번째 댓글", "두 번째 댓글");
+        assertThat(result.getContent())
+                .allMatch(comment -> comment.getParentCommentId() == null);
+    }
+
+    @Test
+    @DisplayName("이슈의 최상위 댓글 페이징 조회")
+    void findByIssueIdAndParentCommentIdIsNull() {
+        // given
+        Long issueId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        
+        CommentEntity comment1 = CommentEntity.builder()
+                .commentId(3L)
+                .content("첫 번째 이슈 댓글")
+                .parentCommentId(null)
+                .build();
+        
+        CommentEntity comment2 = CommentEntity.builder()
+                .commentId(4L)
+                .content("두 번째 이슈 댓글")
+                .parentCommentId(null)
+                .build();
+
+        CommentEntity githubComment = CommentEntity.builder()
+                .commentId(8L)
+                .content("GitHub 동기화 댓글")
+                .parentCommentId(null)
+                .githubId(123456L)
+                .build();
+        
+        List<CommentEntity> comments = Arrays.asList(comment1, comment2, githubComment);
+        Page<CommentEntity> commentPage = new PageImpl<>(comments, pageable, comments.size());
+        
+        given(commentRepository.findByIssueIdAndParentCommentIdIsNull(issueId, pageable))
+                .willReturn(commentPage);
+
+        // when
+        Page<CommentEntity> result = commentRepository.findByIssueIdAndParentCommentIdIsNull(issueId, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent())
+                .extracting(CommentEntity::getContent)
+                .containsExactly("첫 번째 이슈 댓글", "두 번째 이슈 댓글", "GitHub 동기화 댓글");
+        assertThat(result.getContent())
+                .allMatch(comment -> comment.getParentCommentId() == null);
+    }
+
+    @Test
+    @DisplayName("게시글의 특정 최상위 댓글과 대댓글들 조회")
+    void findByPostIdAndParentCommentIds() {
+        // given
+        Long postId = 1L;
+        List<Long> parentCommentIds = List.of(1L);
+        
+        CommentEntity parentComment = CommentEntity.builder()
+                .commentId(1L)
+                .content("첫 번째 댓글")
+                .parentCommentId(null)
+                .build();
+        
+        CommentEntity childComment1 = CommentEntity.builder()
+                .commentId(5L)
+                .content("자식댓글1")
+                .parentCommentId(1L)
+                .build();
+        
+        CommentEntity childComment2 = CommentEntity.builder()
+                .commentId(6L)
+                .content("자식댓글2")
+                .parentCommentId(1L)
+                .build();
+        
+        List<CommentEntity> comments = Arrays.asList(parentComment, childComment1, childComment2);
+        
+        given(commentRepository.findByPostIdAndParentCommentIds(postId, parentCommentIds))
+                .willReturn(comments);
+
+        // when
+        List<CommentEntity> result = commentRepository.findByPostIdAndParentCommentIds(postId, parentCommentIds);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result)
+                .extracting(CommentEntity::getContent)
+                .containsExactly("첫 번째 댓글", "자식댓글1", "자식댓글2");
+    }
+
+    @Test
+    @DisplayName("이슈의 특정 최상위 댓글과 대댓글들 조회")
+    void findByIssueIdAndParentCommentIds() {
+        // given
+        Long issueId = 1L;
+        List<Long> parentCommentIds = List.of(3L);
+        
+        CommentEntity parentComment = CommentEntity.builder()
+                .commentId(3L)
+                .content("첫 번째 이슈 댓글")
+                .parentCommentId(null)
+                .build();
+        
+        CommentEntity childComment = CommentEntity.builder()
+                .commentId(7L)
+                .content("이슈자식댓글1")
+                .parentCommentId(3L)
+                .build();
+        
+        List<CommentEntity> comments = Arrays.asList(parentComment, childComment);
+        
+        given(commentRepository.findByIssueIdAndParentCommentIds(issueId, parentCommentIds))
+                .willReturn(comments);
+
+        // when
+        List<CommentEntity> result = commentRepository.findByIssueIdAndParentCommentIds(issueId, parentCommentIds);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(CommentEntity::getContent)
+                .containsExactly("첫 번째 이슈 댓글", "이슈자식댓글1");
+    }
+
+    @Test
+    @DisplayName("GitHub ID로 이슈 댓글 조회")
+    void findByIssueEntity_IssueIdAndGithubId() {
+        // given
+        Long issueId = 1L;
+        Long githubId = 123456L;
+        
+        CommentEntity comment = CommentEntity.builder()
+                .commentId(8L)
+                .content("GitHub 동기화 댓글")
+                .githubId(githubId)
+                .build();
+        
+        given(commentRepository.findByIssueEntity_IssueIdAndGithubId(issueId, githubId))
+                .willReturn(Optional.of(comment));
+
+        // when
+        Optional<CommentEntity> result = commentRepository.findByIssueEntity_IssueIdAndGithubId(issueId, githubId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getContent()).isEqualTo("GitHub 동기화 댓글");
+        assertThat(result.get().getGithubId()).isEqualTo(githubId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 GitHub ID로 조회시 빈 결과 반환")
+    void findByIssueEntity_IssueIdAndGithubId_NotFound() {
+        // given
+        Long issueId = 1L;
+        Long nonExistentGithubId = 999999L;
+        
+        given(commentRepository.findByIssueEntity_IssueIdAndGithubId(issueId, nonExistentGithubId))
+                .willReturn(Optional.empty());
+
+        // when
+        Optional<CommentEntity> result = commentRepository.findByIssueEntity_IssueIdAndGithubId(issueId, nonExistentGithubId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/ourhour/domain/comment/service/CommentLikeServiceTest.java
+++ b/backend/src/test/java/com/ourhour/domain/comment/service/CommentLikeServiceTest.java
@@ -1,0 +1,287 @@
+package com.ourhour.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ourhour.domain.comment.entity.CommentEntity;
+import com.ourhour.domain.comment.entity.CommentLikeEntity;
+import com.ourhour.domain.comment.entity.CommentLikeId;
+import com.ourhour.domain.comment.exception.CommentException;
+import com.ourhour.domain.comment.repository.CommentLikeRepository;
+import com.ourhour.domain.comment.repository.CommentRepository;
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.exception.MemberException;
+import com.ourhour.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentLikeService 테스트")
+class CommentLikeServiceTest {
+
+    @Mock
+    private CommentLikeRepository commentLikeRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private CommentLikeService commentLikeService;
+
+    private CommentEntity comment;
+    private MemberEntity member;
+    private CommentLikeId commentLikeId;
+    private CommentLikeEntity commentLike;
+
+    @BeforeEach
+    void setUp() {
+        comment = CommentEntity.builder()
+                .commentId(1L)
+                .content("테스트 댓글")
+                .build();
+
+        member = MemberEntity.builder()
+                .name("테스트 사용자")
+                .email("test@example.com")
+                .build();
+
+        commentLikeId = new CommentLikeId(1L, 1L);
+
+        commentLike = CommentLikeEntity.builder()
+                .commentLikeId(commentLikeId)
+                .commentEntity(comment)
+                .memberEntity(member)
+                .build();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 성공")
+    void likeComment_Success() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(false);
+        given(commentLikeRepository.save(any(CommentLikeEntity.class))).willReturn(commentLike);
+
+        // when
+        commentLikeService.likeComment(commentId, memberId);
+
+        // then
+        then(commentRepository).should().findById(commentId);
+        then(memberRepository).should().findById(memberId);
+        then(commentLikeRepository).should().existsById(commentLikeId);
+        then(commentLikeRepository).should().save(any(CommentLikeEntity.class));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 시 댓글이 존재하지 않는 경우 예외 발생")
+    void likeComment_CommentNotFound_ThrowsException() {
+        // given
+        Long commentId = 999L;
+        Long memberId = 1L;
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.likeComment(commentId, memberId))
+                .isInstanceOf(CommentException.class);
+
+        then(memberRepository).shouldHaveNoInteractions();
+        then(commentLikeRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 시 회원이 존재하지 않는 경우 예외 발생")
+    void likeComment_MemberNotFound_ThrowsException() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 999L;
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.likeComment(commentId, memberId))
+                .isInstanceOf(MemberException.class);
+
+        then(commentLikeRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 시 이미 좋아요를 누른 경우 예외 발생")
+    void likeComment_AlreadyLiked_ThrowsException() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.likeComment(commentId, memberId))
+                .isInstanceOf(CommentException.class);
+
+        then(commentLikeRepository).should().existsById(commentLikeId);
+        then(commentLikeRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 성공")
+    void unlikeComment_Success() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentRepository.existsById(commentId)).willReturn(true);
+        given(memberRepository.existsById(memberId)).willReturn(true);
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(true);
+
+        // when
+        commentLikeService.unlikeComment(commentId, memberId);
+
+        // then
+        then(commentRepository).should().existsById(commentId);
+        then(memberRepository).should().existsById(memberId);
+        then(commentLikeRepository).should().existsById(commentLikeId);
+        then(commentLikeRepository).should().deleteById(commentLikeId);
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 시 댓글이 존재하지 않는 경우 예외 발생")
+    void unlikeComment_CommentNotFound_ThrowsException() {
+        // given
+        Long commentId = 999L;
+        Long memberId = 1L;
+
+        given(commentRepository.existsById(commentId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.unlikeComment(commentId, memberId))
+                .isInstanceOf(CommentException.class);
+
+        then(memberRepository).shouldHaveNoInteractions();
+        then(commentLikeRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 시 회원이 존재하지 않는 경우 예외 발생")
+    void unlikeComment_MemberNotFound_ThrowsException() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 999L;
+
+        given(commentRepository.existsById(commentId)).willReturn(true);
+        given(memberRepository.existsById(memberId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.unlikeComment(commentId, memberId))
+                .isInstanceOf(MemberException.class);
+
+        then(commentLikeRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 시 좋아요가 존재하지 않는 경우 예외 발생")
+    void unlikeComment_LikeNotFound_ThrowsException() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentRepository.existsById(commentId)).willReturn(true);
+        given(memberRepository.existsById(memberId)).willReturn(true);
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> commentLikeService.unlikeComment(commentId, memberId))
+                .isInstanceOf(CommentException.class);
+
+        then(commentLikeRepository).should().existsById(commentLikeId);
+        then(commentLikeRepository).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 수 조회")
+    void getLikeCount() {
+        // given
+        Long commentId = 1L;
+        Long expectedCount = 5L;
+
+        given(commentLikeRepository.countByCommentId(commentId)).willReturn(expectedCount);
+
+        // when
+        Long actualCount = commentLikeService.getLikeCount(commentId);
+
+        // then
+        assertThat(actualCount).isEqualTo(expectedCount);
+        then(commentLikeRepository).should().countByCommentId(commentId);
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 댓글에 좋아요를 눌렀는지 확인 - 좋아요를 누른 경우")
+    void isLikedByMember_LikedByUser_ReturnsTrue() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(true);
+
+        // when
+        boolean isLiked = commentLikeService.isLikedByMember(commentId, memberId);
+
+        // then
+        assertThat(isLiked).isTrue();
+        then(commentLikeRepository).should().existsById(commentLikeId);
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 댓글에 좋아요를 눌렀는지 확인 - 좋아요를 누르지 않은 경우")
+    void isLikedByMember_NotLikedByUser_ReturnsFalse() {
+        // given
+        Long commentId = 1L;
+        Long memberId = 1L;
+
+        given(commentLikeRepository.existsById(commentLikeId)).willReturn(false);
+
+        // when
+        boolean isLiked = commentLikeService.isLikedByMember(commentId, memberId);
+
+        // then
+        assertThat(isLiked).isFalse();
+        then(commentLikeRepository).should().existsById(commentLikeId);
+    }
+
+    @Test
+    @DisplayName("좋아요 수 조회 시 0개인 경우")
+    void getLikeCount_ZeroLikes() {
+        // given
+        Long commentId = 1L;
+        Long expectedCount = 0L;
+
+        given(commentLikeRepository.countByCommentId(commentId)).willReturn(expectedCount);
+
+        // when
+        Long actualCount = commentLikeService.getLikeCount(commentId);
+
+        // then
+        assertThat(actualCount).isEqualTo(0L);
+        then(commentLikeRepository).should().countByCommentId(commentId);
+    }
+}

--- a/backend/src/test/java/com/ourhour/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/ourhour/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,395 @@
+package com.ourhour.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.ourhour.domain.comment.dto.CommentCreateReqDTO;
+import com.ourhour.domain.comment.dto.CommentPageResDTO;
+import com.ourhour.domain.comment.dto.CommentResDTO;
+import com.ourhour.domain.comment.dto.CommentUpdateReqDTO;
+import com.ourhour.domain.comment.entity.CommentEntity;
+import com.ourhour.domain.comment.exception.CommentException;
+import com.ourhour.domain.comment.mapper.CommentMapper;
+import com.ourhour.domain.comment.repository.CommentRepository;
+import com.ourhour.domain.board.entity.PostEntity;
+import com.ourhour.domain.board.repository.PostRepository;
+import com.ourhour.domain.member.entity.MemberEntity;
+import com.ourhour.domain.member.repository.MemberRepository;
+import com.ourhour.domain.project.entity.IssueEntity;
+import com.ourhour.domain.project.repository.IssueRepository;
+import com.ourhour.domain.project.sync.GitHubSyncManager;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentService 테스트")
+class CommentServiceTest {
+
+        @Mock
+        private CommentRepository commentRepository;
+
+        @Mock
+        private CommentMapper commentMapper;
+
+        @Mock
+        private MemberRepository memberRepository;
+
+        @Mock
+        private PostRepository postRepository;
+
+        @Mock
+        private IssueRepository issueRepository;
+
+        @Mock
+        private CommentLikeService commentLikeService;
+
+        @Mock
+        private GitHubSyncManager gitHubSyncManager;
+
+        @InjectMocks
+        private CommentService commentService;
+
+        private MemberEntity member;
+        private PostEntity post;
+        private IssueEntity issue;
+        private CommentEntity comment;
+        private CommentCreateReqDTO createReqDTO;
+        private CommentUpdateReqDTO updateReqDTO;
+
+        @BeforeEach
+        void setUp() {
+                member = mock(MemberEntity.class);
+                post = mock(PostEntity.class);
+                issue = mock(IssueEntity.class);
+                comment = mock(CommentEntity.class);
+
+                createReqDTO = new CommentCreateReqDTO();
+                updateReqDTO = new CommentUpdateReqDTO();
+        }
+
+        @Test
+        @DisplayName("게시글 댓글 목록 조회 성공")
+        void getComments_Post_Success() {
+                // given
+                Long postId = 1L;
+                Long issueId = null;
+                int currentPage = 1;
+                int size = 10;
+                Long currentMemberId = 1L;
+
+                Pageable pageable = PageRequest.of(0, size); // currentPage = 1이므로 0
+                Page<CommentEntity> parentComments = new PageImpl<>(List.of(comment), pageable, 1);
+                List<CommentEntity> allComments = List.of(comment);
+
+                given(commentRepository.findByPostIdAndParentCommentIdIsNull(any(), any(Pageable.class)))
+                                .willReturn(parentComments);
+                given(commentRepository.findByPostIdAndParentCommentIds(any(), anyList()))
+                                .willReturn(allComments);
+                given(commentMapper.toCommentResDTO(any(), any(), any(),
+                                any(), any()))
+                                .willReturn(mock(CommentResDTO.class));
+
+                // when
+                CommentPageResDTO result = commentService.getComments(postId, issueId, currentPage, size,
+                                currentMemberId);
+
+                // then
+                assertThat(result).isNotNull();
+                then(commentRepository).should().findByPostIdAndParentCommentIdIsNull(postId, pageable);
+                then(commentRepository).should().findByPostIdAndParentCommentIds(eq(postId), anyList());
+        }
+
+        @Test
+        @DisplayName("이슈 댓글 목록 조회 성공")
+        void getComments_Issue_Success() {
+                // given
+                Long postId = null;
+                Long issueId = 1L;
+                int currentPage = 1;
+                int size = 10;
+                Long currentMemberId = 1L;
+
+                Pageable pageable = PageRequest.of(0, size); // currentPage = 1이므로 0
+                Page<CommentEntity> parentComments = new PageImpl<>(List.of(comment), pageable, 1);
+                List<CommentEntity> allComments = List.of(comment);
+
+                given(commentRepository.findByIssueIdAndParentCommentIdIsNull(any(), any(Pageable.class)))
+                                .willReturn(parentComments);
+                given(commentRepository.findByIssueIdAndParentCommentIds(any(), anyList()))
+                                .willReturn(allComments);
+                given(commentMapper.toCommentResDTO(any(), any(), any(),
+                                any(), any()))
+                                .willReturn(mock(CommentResDTO.class));
+
+                // when
+                CommentPageResDTO result = commentService.getComments(postId, issueId, currentPage, size,
+                                currentMemberId);
+
+                // then
+                assertThat(result).isNotNull();
+                then(commentRepository).should().findByIssueIdAndParentCommentIdIsNull(issueId, pageable);
+                then(commentRepository).should().findByIssueIdAndParentCommentIds(eq(issueId), anyList());
+        }
+
+        @Test
+        @DisplayName("댓글 목록 조회 시 postId와 issueId 모두 null인 경우 예외 발생")
+        void getComments_BothIdsNull_ThrowsException() {
+                // given
+                Long postId = null;
+                Long issueId = null;
+                int currentPage = 1;
+                int size = 10;
+                Long currentMemberId = 1L;
+
+                // when & then
+                assertThatThrownBy(
+                                () -> commentService.getComments(postId, issueId, currentPage, size, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 목록 조회 시 postId와 issueId 모두 존재하는 경우 예외 발생")
+        void getComments_BothIdsPresent_ThrowsException() {
+                // given
+                Long postId = 1L;
+                Long issueId = 1L;
+                int currentPage = 1;
+                int size = 10;
+                Long currentMemberId = 1L;
+
+                // when & then
+                assertThatThrownBy(
+                                () -> commentService.getComments(postId, issueId, currentPage, size, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("게시글 댓글 생성 성공")
+        void createComment_Post_Success() {
+                // given
+                Long currentMemberId = 1L;
+                createReqDTO.setPostId(1L);
+                createReqDTO.setIssueId(null);
+                createReqDTO.setContent("테스트 댓글");
+
+                given(memberRepository.findById(currentMemberId)).willReturn(Optional.of(member));
+                given(postRepository.findById(1L)).willReturn(Optional.of(post));
+                given(commentRepository.save(any(CommentEntity.class))).willReturn(comment);
+
+                // when
+                commentService.createComment(createReqDTO, currentMemberId);
+
+                // then
+                then(memberRepository).should().findById(currentMemberId);
+                then(postRepository).should().findById(1L);
+                then(commentRepository).should().save(any(CommentEntity.class));
+                then(issueRepository).should(never()).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("이슈 댓글 생성 성공")
+        void createComment_Issue_Success() {
+                // given
+                Long currentMemberId = 1L;
+                createReqDTO.setPostId(null);
+                createReqDTO.setIssueId(1L);
+                createReqDTO.setContent("테스트 댓글");
+
+                given(memberRepository.findById(currentMemberId)).willReturn(Optional.of(member));
+                given(issueRepository.findById(1L)).willReturn(Optional.of(issue));
+                given(commentRepository.save(any(CommentEntity.class))).willReturn(comment);
+
+                // when
+                commentService.createComment(createReqDTO, currentMemberId);
+
+                // then
+                then(memberRepository).should().findById(currentMemberId);
+                then(issueRepository).should().findById(1L);
+                then(commentRepository).should().save(any(CommentEntity.class));
+                then(postRepository).should(never()).findById(anyLong());
+        }
+
+        @Test
+        @DisplayName("댓글 생성 시 postId와 issueId 모두 null인 경우 예외 발생")
+        void createComment_BothIdsNull_ThrowsException() {
+                // given
+                Long currentMemberId = 1L;
+                createReqDTO.setPostId(null);
+                createReqDTO.setIssueId(null);
+                createReqDTO.setContent("테스트 댓글");
+
+                // when & then
+                assertThatThrownBy(() -> commentService.createComment(createReqDTO, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 생성 시 postId와 issueId 모두 존재하는 경우 예외 발생")
+        void createComment_BothIdsPresent_ThrowsException() {
+                // given
+                Long currentMemberId = 1L;
+                createReqDTO.setPostId(1L);
+                createReqDTO.setIssueId(1L);
+                createReqDTO.setContent("테스트 댓글");
+
+                // when & then
+                assertThatThrownBy(() -> commentService.createComment(createReqDTO, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 생성 시 내용이 비어있는 경우 예외 발생")
+        void createComment_EmptyContent_ThrowsException() {
+                // given
+                Long currentMemberId = 1L;
+                createReqDTO.setPostId(1L);
+                createReqDTO.setContent(""); // 빈 내용으로 설정
+
+                // when & then
+                assertThatThrownBy(() -> commentService.createComment(createReqDTO, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 수정 성공")
+        void updateComment_Success() {
+                // given
+                Long commentId = 1L;
+                Long currentMemberId = 1L;
+                updateReqDTO.setContent("테스트 댓글 수정정");
+
+                given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+                given(commentRepository.save(any(CommentEntity.class))).willReturn(comment);
+
+                // when
+                commentService.updateComment(commentId, updateReqDTO, currentMemberId);
+
+                // then
+                then(commentRepository).should().findById(commentId);
+                then(commentMapper).should().updateCommentEntity(comment, updateReqDTO);
+                then(commentRepository).should().save(comment);
+        }
+
+        @Test
+        @DisplayName("댓글 수정 시 댓글이 존재하지 않는 경우 예외 발생")
+        void updateComment_CommentNotFound_ThrowsException() {
+                // given
+                Long commentId = 999L;
+                Long currentMemberId = 1L;
+                updateReqDTO.setContent("유효한 내용"); // 검증을 통과하기 위해 유효한 내용 설정
+
+                given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> commentService.updateComment(commentId, updateReqDTO, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 수정 시 내용이 비어있는 경우 예외 발생")
+        void updateComment_EmptyContent_ThrowsException() {
+                // given
+                Long commentId = 1L;
+                Long currentMemberId = 1L;
+                updateReqDTO.setContent("");
+
+                // when & then
+                assertThatThrownBy(() -> commentService.updateComment(commentId, updateReqDTO, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 성공")
+        void deleteComment_Success() {
+                // given
+                Long commentId = 1L;
+                Long currentMemberId = 1L;
+                // Mock 객체 설정
+                given(member.getMemberId()).willReturn(1L);
+                given(comment.getAuthorEntity()).willReturn(member);
+
+                given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+                // when
+                commentService.deleteComment(commentId, currentMemberId);
+
+                // then
+                then(commentRepository).should().findById(commentId);
+                then(commentRepository).should().delete(comment);
+        }
+
+        @Test
+        @DisplayName("이슈 댓글 삭제 시 GitHub 동기화 호출")
+        void deleteComment_IssueComment_CallsGitHubSync() {
+                // given
+                Long commentId = 1L;
+                Long currentMemberId = 1L;
+
+                // Mock 객체 설정
+                given(member.getMemberId()).willReturn(currentMemberId);
+                given(comment.getAuthorEntity()).willReturn(member);
+                given(comment.getIssueEntity()).willReturn(issue);
+
+                given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+                // when
+                commentService.deleteComment(commentId, currentMemberId);
+
+                // then
+                then(commentRepository).should().findById(commentId);
+                then(commentRepository).should().delete(comment);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 시 작성자가 아닌 경우 예외 발생")
+        void deleteComment_NotAuthor_ThrowsException() {
+                // given
+                Long commentId = 1L;
+                Long differentMemberId = 999L;
+
+                // Mock 설정: 작성자 ID는 1L, 요청자 ID는 999L로 다르게 설정
+                given(member.getMemberId()).willReturn(1L);
+                given(comment.getAuthorEntity()).willReturn(member);
+                given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+                // when & then
+                assertThatThrownBy(() -> commentService.deleteComment(commentId, differentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+
+        @Test
+        @DisplayName("댓글 삭제 시 댓글이 존재하지 않는 경우 예외 발생")
+        void deleteComment_CommentNotFound_ThrowsException() {
+                // given
+                Long commentId = 999L;
+                Long currentMemberId = 1L;
+
+                given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> commentService.deleteComment(commentId, currentMemberId))
+                                .isInstanceOf(CommentException.class);
+        }
+}


### PR DESCRIPTION
## 📌 제목
feat(be): 댓글 도메인 단위 테스트 코드 추가

----------------------------------------

## 🔗 관련 이슈

## ✅ 작업 내용
- 댓글 좋아요 기능에 memberId param 제거 -> orgId + 토큰으로 변경
- 댓글 목록 조회 1-based로 수정
- 댓글 도메인 모든 단위 테스트코드 추가

## 📝 기타 참고 사항


