### PR TITLE
feat(be): 채팅 기능 백엔드 API 일부 수정

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
@@ -103,13 +103,15 @@ public class ChatRestController {
     @OrgAuth(accessLevel = Role.MEMBER)
     @GetMapping("/{roomId}/messages")
     @Operation(summary = "메시지 목록 조회", description = "특정 채팅방의 메시지 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<ChatMessageResDTO>>> getMessages(
+    public ResponseEntity<ApiResponse<PageResponse<ChatMessageResDTO>>> getMessages(
             @OrgId @PathVariable Long orgId,
-            @PathVariable Long roomId) {
+            @PathVariable Long roomId,
+            Pageable pageable) {
 
-        List<ChatMessageResDTO> chatMessages = chatService.findAllMessages(orgId, roomId);
+        Page<ChatMessageResDTO> chatMessages = chatService.findAllMessages(orgId, roomId, pageable);
+        System.out.println("Received Pageable: " + pageable);
 
-        return ResponseEntity.ok(ApiResponse.success(chatMessages, "채팅 메시지 조회에 성공했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.of(chatMessages), "채팅 메시지 조회에 성공했습니다."));
     }
 
     @OrgAuth(accessLevel = Role.MEMBER)

--- a/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/controller/ChatRestController.java
@@ -5,10 +5,13 @@ import com.ourhour.domain.chat.service.ChatService;
 import com.ourhour.domain.member.exception.MemberException;
 import com.ourhour.domain.org.enums.Role;
 import com.ourhour.global.common.dto.ApiResponse;
+import com.ourhour.global.common.dto.PageResponse;
 import com.ourhour.global.jwt.annotation.OrgAuth;
 import com.ourhour.global.jwt.annotation.OrgId;
 import com.ourhour.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,18 +36,19 @@ public class ChatRestController {
 
     @OrgAuth(accessLevel = Role.MEMBER)
     @GetMapping
-    @Operation(summary = "채팅방 목록 조회", description = "조직 내 채팅방 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<ChatRoomListResDTO>>> getAllChatRooms(
-            @OrgId @PathVariable Long orgId) {
+    @Operation(summary = "채팅방 목록 조회", description = "조직 내 참여중인 채팅방 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<PageResponse<ChatRoomListResDTO>>> getAllChatRooms(
+            @OrgId @PathVariable Long orgId,
+            Pageable pageable) {
 
         Long memberId = SecurityUtil.getCurrentMemberIdByOrgId(orgId);
         if (memberId == null) {
             throw MemberException.memberAccessDeniedException();
         }
 
-        List<ChatRoomListResDTO> chatRooms = chatService.findAllChatRooms(orgId, memberId);
+        Page<ChatRoomListResDTO> chatRoomsPage = chatService.findAllChatRoomsOrderByLastMessage(orgId, memberId, pageable);
 
-        return ResponseEntity.ok(ApiResponse.success(chatRooms, "채팅방 목록 조회에 성공했습니다."));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.of(chatRoomsPage), "채팅방 목록 조회에 성공했습니다."));
     }
 
     @OrgAuth(accessLevel = Role.MEMBER)

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
@@ -20,7 +20,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
             "       m.sentAt) " +
             "FROM   ChatMessageEntity m " +
             "WHERE  m.chatRoomEntity.orgEntity.orgId = :orgId AND m.chatRoomEntity.roomId = :roomId " +
-            "ORDER BY m.sentAt DESC")
+            "ORDER BY m.sentAt ASC")
     Page<ChatMessageResDTO> findAllByOrgAndChatRoom(@Param("orgId") Long orgId, @Param("roomId") Long roomId, Pageable pageable);
 
     @Modifying

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
@@ -2,11 +2,11 @@ package com.ourhour.domain.chat.repository;
 
 import com.ourhour.domain.chat.dto.ChatMessageResDTO;
 import com.ourhour.domain.chat.entity.ChatMessageEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
 
@@ -19,6 +19,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
             "       m.sentAt) " +
             "FROM   ChatMessageEntity m " +
             "WHERE  m.chatRoomEntity.orgEntity.orgId = :orgId AND m.chatRoomEntity.roomId = :roomId " +
-            "ORDER BY m.sentAt ASC")
-    List<ChatMessageResDTO> findAllByOrgAndChatRoom(@Param("orgId") Long orgId, @Param("roomId") Long roomId);
+            "ORDER BY m.sentAt DESC")
+    Page<ChatMessageResDTO> findAllByOrgAndChatRoom(@Param("orgId") Long orgId, @Param("roomId") Long roomId, Pageable pageable);
 }

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatMessageRepository.java
@@ -5,6 +5,7 @@ import com.ourhour.domain.chat.entity.ChatMessageEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +22,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
             "WHERE  m.chatRoomEntity.orgEntity.orgId = :orgId AND m.chatRoomEntity.roomId = :roomId " +
             "ORDER BY m.sentAt DESC")
     Page<ChatMessageResDTO> findAllByOrgAndChatRoom(@Param("orgId") Long orgId, @Param("roomId") Long roomId, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM ChatMessageEntity cm WHERE cm.chatRoomEntity.roomId = :roomId")
+    void deleteAllByChatRoomEntity_RoomId(@Param("roomId") Long roomId);
 }

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
@@ -1,7 +1,10 @@
 package com.ourhour.domain.chat.repository;
 
+import com.ourhour.domain.chat.dto.ChatRoomListResDTO;
 import com.ourhour.domain.chat.entity.ChatParticipantEntity;
 import com.ourhour.domain.chat.entity.ChatParticipantId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +20,25 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             "WHERE cr.orgEntity.orgId = :orgId " +
             "AND cp.memberEntity.memberId = :memberId")
     List<ChatParticipantEntity> findChatRoomsByOrgAndMember(@Param("orgId") Long orgId, @Param("memberId") Long memberId);
+
+    @Query(value = "SELECT NEW com.ourhour.domain.chat.dto.ChatRoomListResDTO(" +
+            "           cr.roomId, " +
+            "           cr.name, " +
+            "           cr.color, " +
+            "           cm.content, " +
+            "           cm.sentAt) " +
+            "FROM ChatParticipantEntity cp " +
+            "JOIN cp.chatRoomEntity cr " +
+            "LEFT JOIN ChatMessageEntity cm ON cm.chatRoomEntity = cr AND cm.chatMessageId = (" +
+            "    SELECT MAX(cm2.chatMessageId) " +
+            "    FROM ChatMessageEntity cm2 " +
+            "    WHERE cm2.chatRoomEntity = cr" +
+            ") " +
+            "WHERE cp.memberEntity.memberId = :memberId " +
+            "AND cr.orgEntity.orgId = :orgId " +
+            "ORDER BY COALESCE(cm.sentAt, cr.createdAt) DESC",
+            countQuery = "SELECT COUNT(cp) FROM ChatParticipantEntity cp WHERE cp.memberEntity.memberId = :memberId AND cp.chatRoomEntity.orgEntity.orgId = :orgId")
+    Page<ChatRoomListResDTO> findChatRoomsWithLastMessage(@Param("orgId") Long orgId, @Param("memberId") Long memberId, Pageable pageable);
 
     @Query("SELECT DISTINCT cp FROM ChatParticipantEntity cp " +
             "JOIN FETCH cp.memberEntity " +

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
@@ -29,7 +29,7 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
             ") " +
             "WHERE cp.memberEntity.memberId = :memberId " +
             "AND cr.orgEntity.orgId = :orgId " +
-            "ORDER BY COALESCE(cm.sentAt, cr.createdAt) DESC",
+            "ORDER BY COALESCE(cm.sentAt) DESC",
             countQuery = "SELECT COUNT(cp) FROM ChatParticipantEntity cp WHERE cp.memberEntity.memberId = :memberId AND cp.chatRoomEntity.orgEntity.orgId = :orgId")
     Page<ChatRoomListResDTO> findChatRoomsWithLastMessage(@Param("orgId") Long orgId, @Param("memberId") Long memberId, Pageable pageable);
 

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
@@ -14,13 +14,6 @@ import java.util.Optional;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipantEntity, ChatParticipantId> {
 
-    @Query("SELECT DISTINCT cp " +
-            "FROM ChatParticipantEntity cp " +
-            "JOIN FETCH cp.chatRoomEntity cr " +
-            "WHERE cr.orgEntity.orgId = :orgId " +
-            "AND cp.memberEntity.memberId = :memberId")
-    List<ChatParticipantEntity> findChatRoomsByOrgAndMember(@Param("orgId") Long orgId, @Param("memberId") Long memberId);
-
     @Query(value = "SELECT NEW com.ourhour.domain.chat.dto.ChatRoomListResDTO(" +
             "           cr.roomId, " +
             "           cr.name, " +

--- a/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/repository/ChatParticipantRepository.java
@@ -47,4 +47,6 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
                                                              @Param("roomId") Long roomId,
                                                              @Param("memberId") Long memberId
     );
+
+    int countByChatRoomEntity_RoomId(Long roomId);
 }

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -99,9 +99,9 @@ public class ChatService {
         chatRoomRepository.deleteByOrgEntity_OrgIdAndRoomId(orgId, roomId);
     }
 
-    public List<ChatMessageResDTO> findAllMessages(Long orgId, Long roomId) {
+    public Page<ChatMessageResDTO> findAllMessages(Long orgId, Long roomId, Pageable pageable) {
 
-        return chatMessageRepository.findAllByOrgAndChatRoom(orgId, roomId);
+        return chatMessageRepository.findAllByOrgAndChatRoom(orgId, roomId, pageable);
     }
 
     public List<ChatParticipantResDTO> findAllParticipants(Long orgId, Long roomId) {

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -16,8 +16,11 @@ import com.ourhour.domain.org.entity.OrgEntity;
 import com.ourhour.domain.org.exception.OrgException;
 import com.ourhour.domain.org.repository.OrgParticipantMemberRepository;
 import com.ourhour.domain.org.repository.OrgRepository;
+import com.ourhour.global.common.dto.PageResponse;
 import com.ourhour.global.jwt.dto.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +49,11 @@ public class ChatService {
         return participants.stream()
                 .map(chatMapper::toChatRoomListResDTO)
                 .collect(Collectors.toList());
+    }
+
+    public Page<ChatRoomListResDTO> findAllChatRoomsOrderByLastMessage(Long orgId, Long memberId, Pageable pageable) {
+
+        return chatParticipantRepository.findChatRoomsWithLastMessage(orgId, memberId, pageable);
     }
 
     public ChatRoomDetailResDTO findChatRoom(Long orgId, Long roomId) {

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -132,6 +132,9 @@ public class ChatService {
                 .findParticipantToDelete(orgId, roomId, memberId)
                 .orElseThrow(ChatException::chatNotParticipantException);
 
+        if (chatParticipantRepository.countByChatRoomEntity_RoomId(roomId) == 0) {
+            chatRoomRepository.deleteById(roomId);
+        }
         chatParticipantRepository.delete(participantToDelete);
     }
 

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -41,16 +41,6 @@ public class ChatService {
     private final OrgRepository orgRepository;
     private final OrgParticipantMemberRepository orgParticipantMemberRepository;
 
-    public List<ChatRoomListResDTO> findAllChatRooms(Long orgId, Long memberId) {
-
-        List<ChatParticipantEntity> participants = chatParticipantRepository.findChatRoomsByOrgAndMember(orgId,
-                memberId);
-
-        return participants.stream()
-                .map(chatMapper::toChatRoomListResDTO)
-                .collect(Collectors.toList());
-    }
-
     public Page<ChatRoomListResDTO> findAllChatRoomsOrderByLastMessage(Long orgId, Long memberId, Pageable pageable) {
 
         return chatParticipantRepository.findChatRoomsWithLastMessage(orgId, memberId, pageable);

--- a/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
+++ b/backend/src/main/java/com/ourhour/domain/chat/service/ChatService.java
@@ -132,10 +132,12 @@ public class ChatService {
                 .findParticipantToDelete(orgId, roomId, memberId)
                 .orElseThrow(ChatException::chatNotParticipantException);
 
+        chatParticipantRepository.delete(participantToDelete);
+
         if (chatParticipantRepository.countByChatRoomEntity_RoomId(roomId) == 0) {
+            chatMessageRepository.deleteAllByChatRoomEntity_RoomId(roomId);
             chatRoomRepository.deleteById(roomId);
         }
-        chatParticipantRepository.delete(participantToDelete);
     }
 
     @Transactional

--- a/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ourhour/global/jwt/filter/JwtAuthenticationFilter.java
@@ -26,6 +26,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String requestURI = request.getRequestURI();
 
+        if (requestURI.startsWith("/ws-stomp/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         boolean isPublic = Arrays.stream(AuthPath.PUBLIC_URLS)
                 .anyMatch(requestURI::startsWith);
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #241

## ✅ 작업 내용
- 채팅 목록에 페이지네이션을 적용하고, 최근 메시지를 함께 조회하여 최근 메시지/방 생성일자 순으로 정렬하여 반환하도록 수정하였습니다.
- 채팅 메시지 조회에 페이지네이션을 적용하였습니다.
- 채팅방 참여자 삭제 시, 채팅방 참여 인원이 0명이 될 경우 해당 채팅방의 메시지와 채팅방을 삭제하는 로직을 추가하였습니다.

## 📝 기타 참고 사항
- x

