### PR TITLE
refactor: 계정 탈퇴 관련 오류 수정 및 멤버 초대 시 루트 관리자 권한 정책 적용

### DIFF
--- a/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
+++ b/backend/src/main/java/com/ourhour/domain/org/repository/OrgParticipantMemberRepository.java
@@ -76,7 +76,7 @@ public interface OrgParticipantMemberRepository
                         "AND opm.memberEntity.memberId=:memberId ")
         MemberInfoResDTO findByOrgIdAndMemberId(@Param("orgId") Long orgId, @Param("memberId") Long memberId);
 
-        @Modifying(clearAutomatically = true, flushAutomatically = true)
+        @Modifying(flushAutomatically = true)
         @Query("""
                             update OrgParticipantMemberEntity opm
                                set opm.status = :inactive,
@@ -94,11 +94,6 @@ public interface OrgParticipantMemberRepository
 
         // 해당 회사의 권한에 따른 멤버 수 집계
         int countByOrgEntity_OrgIdAndRole(Long orgId, Role role);
-
-        // 권한이 루트 관리자인 멤버만 집계
-        default int countRootAdmins(Long orgId) {
-                return countByOrgEntity_OrgIdAndRole(orgId, Role.ROOT_ADMIN);
-        }
 
         List<OrgParticipantMemberEntity> findAllByMemberEntity_MemberIdAndStatus(Long memberId, Status status);
 

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgMemberService.java
@@ -169,7 +169,7 @@ public class OrgMemberService {
 
         Role oldRole = orgParticipantMemberEntity.getRole();
         Role newRole = orgMemberRoleReqDTO.getRole();
-        int currentRootAdminCount = orgParticipantMemberRepository.countRootAdmins(orgId);
+        int currentRootAdminCount = orgRoleGuardService.countActiveRootAdmins(orgId);
 
         // 동일 권한 변경일 경우 early return(정책 위반 아님)
         if (oldRole == newRole) {

--- a/backend/src/main/java/com/ourhour/domain/org/service/OrgRoleGuardService.java
+++ b/backend/src/main/java/com/ourhour/domain/org/service/OrgRoleGuardService.java
@@ -125,7 +125,7 @@ public class OrgRoleGuardService {
     }
 
     // 조직 내 활성 루트 관리자 조회
-    private int countActiveRootAdmins(Long orgId) {
+    public int countActiveRootAdmins(Long orgId) {
         return orgParticipantMemberRepository
                 .countByOrgEntity_OrgIdAndRoleAndStatus(orgId, Role.ROOT_ADMIN, Status.ACTIVE);
     }

--- a/backend/src/test/java/com/ourhour/domain/org/service/OrgMemberServiceTest.java
+++ b/backend/src/test/java/com/ourhour/domain/org/service/OrgMemberServiceTest.java
@@ -358,7 +358,7 @@ class OrgMemberServiceTest {
 
         given(orgParticipantMemberRepository.findByOrgEntity_OrgIdAndMemberEntity_MemberIdAndStatus(orgId, memberId, Status.ACTIVE))
                 .willReturn(Optional.of(participant));
-        given(orgParticipantMemberRepository.countRootAdmins(orgId)).willReturn(2);
+        given(orgParticipantMemberRepository.countByOrgEntity_OrgIdAndRole(orgId, Role.ROOT_ADMIN)).willReturn(2);
         given(orgParticipantMemberMapper.toOrgMemberRoleResDTO(any(), any(), any(Integer.class))).willReturn(roleResDTO);
 
         // when

--- a/backend/src/test/java/com/ourhour/domain/org/service/OrgMemberServiceTest.java
+++ b/backend/src/test/java/com/ourhour/domain/org/service/OrgMemberServiceTest.java
@@ -358,7 +358,7 @@ class OrgMemberServiceTest {
 
         given(orgParticipantMemberRepository.findByOrgEntity_OrgIdAndMemberEntity_MemberIdAndStatus(orgId, memberId, Status.ACTIVE))
                 .willReturn(Optional.of(participant));
-        given(orgParticipantMemberRepository.countByOrgEntity_OrgIdAndRole(orgId, Role.ROOT_ADMIN)).willReturn(2);
+        given(orgRoleGuardService.countActiveRootAdmins(orgId)).willReturn(2);
         given(orgParticipantMemberMapper.toOrgMemberRoleResDTO(any(), any(), any(Integer.class))).willReturn(roleResDTO);
 
         // when


### PR DESCRIPTION
## 📌 제목
refactor: 계정 탈퇴 관련 오류 수정 및 멤버 초대 시 루트 관리자 권한 정책 적용

## 🔗 관련 이슈
- x

## ✅ 작업 내용
- 계정 탈퇴 시 익명화되지 않았던 오류 수정
- 멤버 초대 시 루트 관리자 권한 정책 적용

## 📝 기타 참고 사항
- x
