### PR TITLE
fix: JWT 필터-비밀번호 재설정 URI 수정

### DIFF
--- a/backend/src/main/java/com/ourhour/global/constant/AuthPath.java
+++ b/backend/src/main/java/com/ourhour/global/constant/AuthPath.java
@@ -12,7 +12,7 @@ public final class AuthPath {
             "/api/auth/oauth-signin/extra-info",
         "/api/auth/email-verification",
         "/api/auth/token",
-        "/api/auth/password-reset"
+        "/api/auth/password-reset/**"
     };
 
     public static final String[] SWAGGER_URLS = {


### PR DESCRIPTION
## 📌 제목
fix: JWT 필터-비밀번호 재설정 URI 수정

## 🔗 관련 이슈
- x

## ✅ 작업 내용
- Jwt 필터에 PUBLIC URLS 중 비밀번호 재설정 URI 수정

## 📝 기타 참고 사항
- x

