### PR TITLE
chore: 테스트 서버 로그 파일 출력을 위한 설정

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -168,11 +168,14 @@ jobs:
             
             docker compose -p ourhour-test up -d
             
-            # 백엔드 로그 파일 만들기
+            # 로그 폴더 생성
             mkdir -p ./logs
-            docker logs -f test-backend | tee ./logs/test-backend.log
+            
+            # 백엔드 로그를 실시간으로 파일에 기록 (백그라운드 실행)
+            nohup docker logs -f test-backend >> ./logs/test-backend.log 2>&1 &
             
             docker image prune -a -f
+
   # 배포용 Docker (main 브랜치)
   deploy-docker-release:
     needs: [build-test, build-docker]
@@ -211,12 +214,6 @@ jobs:
 
             # 새 컨테이너 시작 
             docker compose -p ourhour-release up -d
-            
-            # 로그 폴더 생성
-            mkdir -p ./logs
-  
-            # 현재까지 로그만 파일로 저장 
-            docker logs release-backend > ./logs/release-backend.log 2>&1
 
             # 불필요한 이미지 정리
             docker image prune -a -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## 📌 제목
chore: 테스트 서버 로그 파일 출력을 위한 설정

## 🔗 관련 이슈
- x

## ✅ 작업 내용
- 운영 서버 로그 파일 출력 문구 제거
- 테스트 서버 로그 파일 스트리밍(백그라운드 실행)으로 변경

## 📝 기타 참고 사항
- EC2 서버 접속
- ourhour 프로젝트 접속, 로그파일 접근
```
cd ourhour/logs
```
- 로그 파일 보기
```
cat test-backend.log
```